### PR TITLE
feat: hide project groups by cwd with persistent blacklist

### DIFF
--- a/ClaudeIsland/Core/CompletionPanelController.swift
+++ b/ClaudeIsland/Core/CompletionPanelController.swift
@@ -115,6 +115,10 @@ final class CompletionPanelController: NSObject, ObservableObject {
     }
 
     private func onSessionsUpdate(_ sessions: [SessionState]) {
+        // Drop user-hidden cwds before any state derivation — completion panel,
+        // unattended alert, and "needs you" badges all skip blacklisted projects.
+        let sessions = sessions.filter { !HiddenProjectsStore.shared.isHidden(cwd: $0.cwd) }
+
         lastKnownSessions = Dictionary(uniqueKeysWithValues: sessions.map { ($0.stableId, $0) })
 
         let waitingNow = sessions.filter { $0.phase == .waitingForInput }

--- a/ClaudeIsland/Models/HiddenProjectsStore.swift
+++ b/ClaudeIsland/Models/HiddenProjectsStore.swift
@@ -1,0 +1,76 @@
+//
+//  HiddenProjectsStore.swift
+//  ClaudeIsland
+//
+//  User-managed hidden project list, keyed by absolute cwd path.
+//  Two tiers:
+//    - sessionDismissed: in-memory only, cleared on app restart.
+//    - blacklisted: persisted via UserDefaults, survives restart.
+//  Both tiers cause UI layers to filter the cwd out of all displays.
+//
+
+import Combine
+import Foundation
+import SwiftUI
+
+@MainActor
+final class HiddenProjectsStore: ObservableObject {
+    static let shared = HiddenProjectsStore()
+
+    /// Persisted blacklist (survives restart).
+    @Published private(set) var blacklisted: Set<String> = []
+
+    /// Session-only dismissals (cleared on restart).
+    @Published private(set) var sessionDismissed: Set<String> = []
+
+    private let defaultsKey = "hiddenProjectCwds"
+
+    private init() {
+        if let arr = UserDefaults.standard.array(forKey: defaultsKey) as? [String] {
+            blacklisted = Set(arr)
+        }
+    }
+
+    /// True if the cwd is hidden by either tier.
+    func isHidden(cwd: String) -> Bool {
+        let key = Self.normalize(cwd)
+        return blacklisted.contains(key) || sessionDismissed.contains(key)
+    }
+
+    /// Hide the cwd until next app launch.
+    func dismissForSession(cwd: String) {
+        sessionDismissed.insert(Self.normalize(cwd))
+    }
+
+    /// Add the cwd to the persistent blacklist.
+    func blacklist(cwd: String) {
+        let key = Self.normalize(cwd)
+        blacklisted.insert(key)
+        sessionDismissed.remove(key)  // promote: no need to keep both
+        persist()
+    }
+
+    /// Remove a single cwd from the persistent blacklist.
+    func unblacklist(cwd: String) {
+        blacklisted.remove(Self.normalize(cwd))
+        persist()
+    }
+
+    /// Clear both tiers entirely.
+    func clearAll() {
+        blacklisted.removeAll()
+        sessionDismissed.removeAll()
+        persist()
+    }
+
+    /// Sorted snapshot for settings UI.
+    var allBlacklisted: [String] { blacklisted.sorted() }
+
+    private func persist() {
+        UserDefaults.standard.set(Array(blacklisted), forKey: defaultsKey)
+    }
+
+    private static func normalize(_ cwd: String) -> String {
+        URL(fileURLWithPath: cwd).standardizedFileURL.path
+    }
+}

--- a/ClaudeIsland/UI/Helpers/SessionFilter.swift
+++ b/ClaudeIsland/UI/Helpers/SessionFilter.swift
@@ -19,12 +19,20 @@ enum SessionFilter {
     /// Filter sessions for display:
     /// 1. Hide probe/telemetry sessions from third-party tools.
     /// 2. Hide rate-limit noise (ended sessions that ran < 30s).
-    /// 3. Cap total count to prevent UI freeze with excessive sessions.
-    static func filterForDisplay(_ sessions: [SessionState]) -> [SessionState] {
+    /// 3. Hide user-blacklisted projects (passed via `isHidden` predicate).
+    /// 4. Cap total count to prevent UI freeze with excessive sessions.
+    static func filterForDisplay(
+        _ sessions: [SessionState],
+        isHidden: (String) -> Bool = { _ in false }
+    ) -> [SessionState] {
         let filtered = sessions.filter { session in
             // Filter probe sessions by cwd
             let cwd = session.cwd
             if probeMarkers.contains(where: { cwd.contains($0) }) {
+                return false
+            }
+            // User-hidden projects
+            if isHidden(cwd) {
                 return false
             }
 

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -21,7 +21,16 @@ struct ClaudeInstancesView: View {
     @State private var showBuddyCard: Bool = false
     @AppStorage("usePixelCat") private var usePixelCat: Bool = false
     @ObservedObject private var notchStore: NotchCustomizationStore = .shared
+    @ObservedObject private var hiddenStore: HiddenProjectsStore = .shared
+    /// Pending "hide group" confirmation: set when user clicks the move button.
+    @State private var pendingHide: PendingHide? = nil
     private var theme: ThemeResolver { ThemeResolver(theme: notchStore.customization.theme) }
+
+    private struct PendingHide: Identifiable {
+        let id = UUID()
+        let cwd: String
+        let name: String
+    }
 
     var body: some View {
         if sessionMonitor.instances.isEmpty {
@@ -330,7 +339,8 @@ struct ClaudeInstancesView: View {
     /// Secondary sort: by last user message date (stable - doesn't change when agent responds)
     /// Note: approval requests stay in their date-based position to avoid layout shift
     private var sortedInstances: [SessionState] {
-        SessionFilter.filterForDisplay(sessionMonitor.instances)
+        SessionFilter.filterForDisplay(sessionMonitor.instances,
+                                       isHidden: { hiddenStore.isHidden(cwd: $0) })
         .sorted { a, b in
             let priorityA = phasePriority(a.phase)
             let priorityB = phasePriority(b.phase)
@@ -453,16 +463,20 @@ struct ClaudeInstancesView: View {
                 ForEach(projectGroups) { group in
                     ProjectGroupHeader(
                         group: group,
-                        isCollapsed: collapsedGroups.contains(group.id)
-                    ) {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            if collapsedGroups.contains(group.id) {
-                                collapsedGroups.remove(group.id)
-                            } else {
-                                collapsedGroups.insert(group.id)
+                        isCollapsed: collapsedGroups.contains(group.id),
+                        onToggle: {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                if collapsedGroups.contains(group.id) {
+                                    collapsedGroups.remove(group.id)
+                                } else {
+                                    collapsedGroups.insert(group.id)
+                                }
                             }
+                        },
+                        onMoveRequested: {
+                            pendingHide = PendingHide(cwd: group.id, name: group.name)
                         }
-                    }
+                    )
 
                     if !collapsedGroups.contains(group.id) {
                         ForEach(group.sessions) { session in
@@ -483,6 +497,32 @@ struct ClaudeInstancesView: View {
             .padding(.vertical, 2)
         }
         .scrollBounceBehavior(.basedOnSize)
+        .confirmationDialog(
+            pendingHide.map { L10n.isChinese ? "移除「\($0.name)」" : "Hide \"\($0.name)\"" } ?? "",
+            isPresented: Binding(
+                get: { pendingHide != nil },
+                set: { if !$0 { pendingHide = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingHide
+        ) { hide in
+            Button(L10n.isChinese ? "仅本次隐藏" : "Hide for this session") {
+                hiddenStore.dismissForSession(cwd: hide.cwd)
+                pendingHide = nil
+            }
+            Button(
+                L10n.isChinese ? "永久加入黑名单" : "Add to permanent blacklist",
+                role: .destructive
+            ) {
+                hiddenStore.blacklist(cwd: hide.cwd)
+                pendingHide = nil
+            }
+            Button(L10n.isChinese ? "取消" : "Cancel", role: .cancel) {
+                pendingHide = nil
+            }
+        } message: { hide in
+            Text(hide.cwd)
+        }
     }
 
     // MARK: - Actions
@@ -1091,58 +1131,83 @@ struct ProjectGroupHeader: View {
     let group: ProjectGroup
     let isCollapsed: Bool
     let onToggle: () -> Void
+    let onMoveRequested: () -> Void
 
     @State private var isHovered = false
     @ObservedObject private var notchStore: NotchCustomizationStore = .shared
     private var theme: ThemeResolver { ThemeResolver(theme: notchStore.customization.theme) }
 
     var body: some View {
-        Button {
-            onToggle()
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
-                    .notchFont(11, weight: .semibold)
+        HStack(spacing: 6) {
+            Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                .notchFont(11, weight: .semibold)
+                .notchSecondaryForeground()
+                .frame(width: 12)
+
+            Text(group.name)
+                .notchFont(13, weight: .semibold)
+                .opacity(0.8)
+
+            if group.activeCount > 0 {
+                Text("\(group.activeCount) \(L10n.active)")
+                    .notchFont(11, weight: .medium)
                     .notchSecondaryForeground()
-                    .frame(width: 12)
-
-                Text(group.name)
-                    .notchFont(13, weight: .semibold)
-                    .opacity(0.8)
-
-                if group.activeCount > 0 {
-                    Text("\(group.activeCount) \(L10n.active)")
-                        .notchFont(11, weight: .medium)
-                        .notchSecondaryForeground()
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(theme.overlay.opacity(0.24))
-                        )
-                } else if group.isArchivable {
-                    Text(L10n.archived)
-                        .notchFont(11, weight: .medium)
-                        .notchSecondaryForeground()
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(theme.overlay.opacity(0.18))
-                        )
-                }
-
-                Spacer()
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(theme.overlay.opacity(0.24))
+                    )
+            } else if group.isArchivable {
+                Text(L10n.archived)
+                    .notchFont(11, weight: .medium)
+                    .notchSecondaryForeground()
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(theme.overlay.opacity(0.18))
+                    )
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isHovered ? theme.overlay.opacity(0.16) : Color.clear)
-            )
+
+            Spacer()
+
+            // Hide-this-group affordance (visible on hover).
+            // Sibling Button (NOT nested inside the toggle's Button) so macOS
+            // SwiftUI hit-testing routes the click here, not to the row toggle.
+            if isHovered {
+                Button {
+                    onMoveRequested()
+                } label: {
+                    Image(systemName: "eye.slash")
+                        .notchFont(11, weight: .medium)
+                        .notchSecondaryForeground()
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
+                .help(L10n.isChinese ? "移除此项目" : "Hide this project")
+                .transition(.opacity)
+            }
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovered ? theme.overlay.opacity(0.16) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onToggle()
+        }
         .onHover { isHovered = $0 }
+        .contextMenu {
+            Button {
+                onMoveRequested()
+            } label: {
+                Label(L10n.isChinese ? "移除此项目" : "Hide this project",
+                      systemImage: "eye.slash")
+            }
+        }
     }
 }
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -827,12 +827,14 @@ struct CollapsedNotchContent: View {
         }
     }
 
-    /// Group sessions by project (cwd), preserving order
+    /// Group sessions by project (cwd), preserving order.
+    /// Skips ended and user-hidden cwds.
     private var sessionsByProject: [[SessionState]] {
         var groups: [[SessionState]] = []
         var seen: [String: Int] = [:]  // cwd -> group index
 
         for session in sessions where session.phase != .ended {
+            if HiddenProjectsStore.shared.isHidden(cwd: session.cwd) { continue }
             if let idx = seen[session.cwd] {
                 groups[idx].append(session)
             } else {
@@ -852,6 +854,7 @@ struct CollapsedNotchContent: View {
     @ObservedObject private var buddyReader = BuddyReader.shared
     @AppStorage("usePixelCat") private var usePixelCat: Bool = false
     @ObservedObject private var notchStore: NotchCustomizationStore = .shared
+    @ObservedObject private var hiddenStore: HiddenProjectsStore = .shared
     private var theme: ThemeResolver { ThemeResolver(theme: notchStore.customization.theme) }
 
     // MARK: - Unattended Task Alert

--- a/ClaudeIsland/UI/Views/SystemSettingsView.swift
+++ b/ClaudeIsland/UI/Views/SystemSettingsView.swift
@@ -842,6 +842,71 @@ private struct GeneralTab: View {
             SettingsListCard {
                 SettingsAccessibilityRow(isLast: true)
             }
+
+            // Hidden projects (cwd blacklist)
+            SectionLabel(L10n.isChinese ? "隐藏的项目" : "Hidden Projects")
+            HiddenProjectsCard()
+        }
+    }
+}
+
+/// Lists user-blacklisted project cwds with per-row unblacklist + clear-all.
+private struct HiddenProjectsCard: View {
+    @ObservedObject private var hidden: HiddenProjectsStore = .shared
+
+    var body: some View {
+        SettingsListCard {
+            if hidden.allBlacklisted.isEmpty {
+                HStack {
+                    Text(L10n.isChinese
+                         ? "暂无隐藏的项目。在通知中心列表中右键或悬停项目分组可隐藏它们。"
+                         : "No hidden projects. Right-click or hover a group in the list to hide it.")
+                        .notchFont(11)
+                        .notchSecondaryForeground()
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 4)
+            } else {
+                ForEach(Array(hidden.allBlacklisted.enumerated()), id: \.element) { idx, cwd in
+                    HStack(spacing: 10) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(URL(fileURLWithPath: cwd).lastPathComponent)
+                                .notchFont(13, weight: .medium)
+                            Text(cwd)
+                                .notchFont(11)
+                                .notchSecondaryForeground()
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                        Spacer()
+                        Button(L10n.isChinese ? "取消隐藏" : "Unhide") {
+                            hidden.unblacklist(cwd: cwd)
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.tint)
+                    }
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 4)
+                    if idx < hidden.allBlacklisted.count - 1 {
+                        Divider().opacity(0.4)
+                    }
+                }
+                Divider().opacity(0.4)
+                HStack {
+                    Spacer()
+                    Button(role: .destructive) {
+                        hidden.clearAll()
+                    } label: {
+                        Text(L10n.isChinese ? "清空全部" : "Clear All")
+                            .foregroundStyle(.red)
+                    }
+                    .buttonStyle(.borderless)
+                }
+                .padding(.vertical, 6)
+                .padding(.horizontal, 4)
+            }
         }
     }
 }


### PR DESCRIPTION
## Motivation

Some agent integrations (e.g. claude-mem) spawn background Claude calls that flood MioIsland with noisy summarization sessions the user never wants to see. There is no way to suppress them per-cwd today.

## What this adds

A two-tier hidden-project mechanism, fully UI-driven:

- **Hover** any project group header → click the new `eye.slash` button (or right-click → "Hide this project")
- A confirmation dialog offers three choices:
  - **Hide for this session** — in-memory only, gone on next launch
  - **Add to permanent blacklist** — persisted to UserDefaults
  - **Cancel**
- Hidden groups disappear from list, group counter, completion popup, unattended alert, and "needs you" badge — all consistent
- New **Settings → System → Hidden Projects** section: lists each blacklisted cwd with per-row Unhide and Clear All

## Design

| File | Change |
|---|---|
| `Models/HiddenProjectsStore.swift` | **new** — `@MainActor` singleton, two `@Published` sets, UserDefaults persistence, cwd normalized via `standardizedFileURL` |
| `UI/Helpers/SessionFilter.swift` | `filterForDisplay` gains an `isHidden` predicate parameter (default no-op) — single chokepoint |
| `UI/Views/ClaudeInstancesView.swift` | `ProjectGroupHeader` restructured from nested-Button (which macOS SwiftUI hit-tests incorrectly — clicks fall through to the outer toggle) to `HStack` + `onTapGesture` so the inner `eye.slash` Button absorbs taps cleanly. Adds `.contextMenu` and `.confirmationDialog` |
| `UI/Views/NotchView.swift` | `sessionsByProject` skips hidden cwds; `CollapsedNotchContent` observes the store |
| `Core/CompletionPanelController.swift` | `onSessionsUpdate` filters hidden cwds at the entry |
| `UI/Views/SystemSettingsView.swift` | New "Hidden Projects" section in `GeneralTab` |

## Notes

- Filters at the **UI layer**, not `SessionStore` — hidden sessions are still tracked internally so unhide is instant and lossless.
- cwd is the filter key (not `projectName`) so two unrelated projects with the same last-path-component (e.g. multiple `api/` directories) won not collide.
- Bilingual labels via the existing `L10n.isChinese` pattern.

## Verified

- `xcodebuild Release`: BUILD SUCCEEDED
- End-to-end: hide → group disappears, count drops, defaults written, settings list updates, Unhide restores
- No CPU regression vs baseline