### PR TITLE
feat(updater): add toggle to disable automatic update checks (#87)

### DIFF
--- a/ClaudeIsland/Core/Localization.swift
+++ b/ClaudeIsland/Core/Localization.swift
@@ -185,6 +185,8 @@ enum L10n {
     static var accessibility: String { tr("Accessibility", "辅助功能") }
     static var version: String { tr("Version", "版本") }
     static var checkForUpdates: String { tr("Check for Updates", "检查更新") }
+    static var autoCheckForUpdates: String { tr("Check for Updates Automatically", "自动检查更新") }
+    static var autoCheckForUpdatesHint: String { tr("Turn off if you update via Homebrew", "通过 Homebrew 更新可关闭") }
     static var standby: String { tr("Standby", "待机中") }
     static var quit: String { tr("Quit", "退出") }
     static var on: String { tr("On", "开") }

--- a/ClaudeIsland/Core/UpdaterManager.swift
+++ b/ClaudeIsland/Core/UpdaterManager.swift
@@ -21,6 +21,14 @@ final class UpdaterManager: NSObject, ObservableObject {
 
     @Published var canCheckForUpdates = false
 
+    /// Whether Sparkle performs background update checks on its own schedule.
+    /// Mirrors Sparkle's `automaticallyChecksForUpdates`, which Sparkle persists
+    /// to UserDefaults (`SUEnableAutomaticChecks`) — we don't store it ourselves.
+    /// Exposed so Homebrew users (who let `brew` manage updates) can turn the
+    /// in-app auto-check off. See issue #87. The manual `checkForUpdates()`
+    /// button keeps working regardless of this flag.
+    @Published var automaticallyChecksForUpdates = true
+
     private override init() {
         super.init()
         controller = SPUStandardUpdaterController(
@@ -32,10 +40,20 @@ final class UpdaterManager: NSObject, ObservableObject {
         // Observe Sparkle's canCheckForUpdates KVO property
         controller.updater.publisher(for: \.canCheckForUpdates)
             .assign(to: &$canCheckForUpdates)
+
+        // Mirror Sparkle's auto-check preference so the SwiftUI toggle reflects
+        // the real (persisted) state, including the default seeded from Info.plist.
+        controller.updater.publisher(for: \.automaticallyChecksForUpdates)
+            .assign(to: &$automaticallyChecksForUpdates)
     }
 
     func checkForUpdates() {
         controller.checkForUpdates(nil)
+    }
+
+    /// Toggle Sparkle's background auto-check. Sparkle persists this itself.
+    func setAutomaticUpdateChecks(_ enabled: Bool) {
+        controller.updater.automaticallyChecksForUpdates = enabled
     }
 }
 

--- a/ClaudeIsland/UI/Views/SystemSettingsView.swift
+++ b/ClaudeIsland/UI/Views/SystemSettingsView.swift
@@ -1486,6 +1486,20 @@ private struct CheckForUpdatesCard: View {
 
     var body: some View {
         SettingsCard {
+            // Auto-update opt-out (issue #87): Homebrew users let `brew` manage
+            // updates and want the in-app background check off. Manual check
+            // below still works either way.
+            SettingRow(
+                icon: "clock.arrow.2.circlepath",
+                label: L10n.autoCheckForUpdates,
+                sublabel: L10n.autoCheckForUpdatesHint,
+                isLast: false
+            ) {
+                IOSToggle(isOn: updater.automaticallyChecksForUpdates) {
+                    updater.setAutomaticUpdateChecks(!updater.automaticallyChecksForUpdates)
+                }
+            }
+
             Button {
                 updater.checkForUpdates()
             } label: {


### PR DESCRIPTION
## What & why

Closes #87. A Homebrew user asked for a way to turn off the in-app auto-update check — `brew` already manages updates, so the Sparkle background check is redundant and lags behind brew.

Today there's **no way to disable it**: `UpdaterManager` only mirrored Sparkle's `canCheckForUpdates` and never exposed `automaticallyChecksForUpdates`, and the Settings UI only had a manual "Check for Updates" button.

## Changes

- **`UpdaterManager`**: publish + set Sparkle's `automaticallyChecksForUpdates`. Sparkle persists this itself (UserDefaults `SUEnableAutomaticChecks`) — no custom storage. A KVO publisher mirrors the real state into a `@Published` so the toggle reflects the persisted/default value.
- **`SystemSettingsView`**: add a **"Check for Updates Automatically"** toggle row to About → `CheckForUpdatesCard`, above the existing manual-check button. Reuses the existing `SettingRow` + `IOSToggle` components.
- **`Localization`**: EN/ZH strings for the toggle label + a "Turn off if you update via Homebrew" hint.

## Behavior

- **Default stays ON** (opt-out): unchanged for everyone who doesn't touch it. The issue only asked for the *ability* to disable.
- The manual **Check for Updates** button keeps working regardless of the toggle (Sparkle allows manual checks with auto-check off).

## Test

- `xcodebuild build -scheme ClaudeIsland -configuration Debug` → **BUILD SUCCEEDED**.
- ⚠️ Not yet verified at runtime that the toggle flips + persists across relaunch (would need a launched, signed app session). The wiring mirrors the already-working `canCheckForUpdates` KVO pattern, and Sparkle owns persistence, so risk is low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)