### PR TITLE
fix(cmux): resolve binary across all install paths + robust jump (#49, #62)

### DIFF
--- a/ClaudeIsland/Core/Localization.swift
+++ b/ClaudeIsland/Core/Localization.swift
@@ -244,7 +244,7 @@ enum L10n {
     static var cmuxTabHeader: String { tr("Diagnose the relay between your iPhone and the terminal.", "诊断手机和终端之间的消息转发链路。") }
     static var cmuxBinaryRow: String { tr("cmux CLI", "cmux 命令行") }
     static var cmuxBinaryFound: String { tr("Found", "已找到") }
-    static var cmuxBinaryMissing: String { tr("Not installed at /Applications/cmux.app", "未安装在 /Applications/cmux.app") }
+    static var cmuxBinaryMissing: String { tr("Not found (checked Homebrew, /Applications, ~/Applications)", "未找到（已检查 Homebrew、/Applications、~/Applications）") }
     static var accessibilityRowTitle: String { tr("Accessibility permission", "辅助功能权限") }
     static var accessibilityGranted: String { tr("Granted", "已授权") }
     static var accessibilityDenied: String { tr("Not granted — AppleScript relays will silently fail", "未授权 — AppleScript 转发会静默失败") }

--- a/ClaudeIsland/Services/Cmux/CmuxTreeParser.swift
+++ b/ClaudeIsland/Services/Cmux/CmuxTreeParser.swift
@@ -31,15 +31,33 @@ struct CmuxTreeParser {
     /// the pane in one AppleScript call.
     @discardableResult
     static func jump(cwd: String) async -> Bool {
+        // Normalize so a trailing slash / "." / ".." doesn't defeat the match
+        // (cmux reports a canonical path; the session cwd may not be).
+        let normalized = normalizedPath(cwd)
+        // Guard with `count` instead of `first terminal whose …`: the old form
+        // threw `-1719 Invalid index` whenever NO pane currently had that cwd
+        // (pane closed, cd'd away, path mismatch) — that's exactly the failure
+        // in issue #62. Returning a sentinel lets the caller fall back cleanly.
         let script = """
         tell application "cmux"
-            set targetTerm to (first terminal whose working directory is "\(escapeAS(cwd))")
-            focus targetTerm
+            set matches to (every terminal whose working directory is "\(escapeAS(normalized))")
+            if (count of matches) is 0 then return "none"
+            focus (item 1 of matches)
+            return "ok"
         end tell
         """
-        let ok = await runASAsync(script).isSuccess
-        DebugLogger.log("Cmux", "focus terminal cwd=\"\(cwd)\" ok=\(ok)")
+        let result = (await runASAsync(script).output)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let ok = (result == "ok")
+        DebugLogger.log("Cmux", "focus terminal cwd=\"\(normalized)\" ok=\(ok) result=\(result ?? "nil")")
         return ok
+    }
+
+    /// Canonicalize a filesystem path for matching against cmux's reported
+    /// `working directory` — strips trailing slashes and resolves `.`/`..`.
+    /// (Symlinks are intentionally left unresolved: cmux reports the path the
+    /// shell is actually in, which may itself be a symlink.)
+    private static func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
     }
 
     /// Focus a terminal by its UUID (from session JSON panel id).

--- a/ClaudeIsland/Services/Session/LaunchService.swift
+++ b/ClaudeIsland/Services/Session/LaunchService.swift
@@ -71,21 +71,9 @@ final class LaunchService {
     // MARK: - Helpers
 
     private func findCmuxBinary() -> String? {
-        let candidates = [
-            // Homebrew / user installs
-            "/opt/homebrew/bin/cmux",
-            "/usr/local/bin/cmux",
-            "\(NSHomeDirectory())/.local/bin/cmux",
-            // cmux.app bundle install
-            "/Applications/cmux.app/Contents/Resources/bin/cmux",
-            "\(NSHomeDirectory())/Applications/cmux.app/Contents/Resources/bin/cmux",
-        ]
-        for path in candidates {
-            if FileManager.default.isExecutableFile(atPath: path) {
-                return path
-            }
-        }
-        return nil
+        // Delegates to the shared resolver so the launcher and the phone→terminal
+        // relay (TerminalWriter) agree on where cmux lives. See CmuxBinary.
+        CmuxBinary.resolvedPath()
     }
 
 }

--- a/ClaudeIsland/Services/Shared/CmuxBinary.swift
+++ b/ClaudeIsland/Services/Shared/CmuxBinary.swift
@@ -1,0 +1,83 @@
+//
+//  CmuxBinary.swift
+//  ClaudeIsland
+//
+//  Single source of truth for locating the cmux CLI binary.
+//
+//  Previously `LaunchService` probed five candidate paths while
+//  `TerminalWriter` hardcoded only `/Applications/cmux.app/Contents/Resources/bin/cmux`.
+//  The result: a user whose cmux lives anywhere else (Homebrew, ~/Applications,
+//  a renamed copy) could *launch* sessions fine (LaunchService found it) but
+//  every phone→terminal *relay* silently failed — and the diagnostics tab even
+//  reported "cmux not installed" while cmux was clearly running. See issues
+//  #49 ("brew 安装的 Cmux…发消息没有任何反应") and #62.
+//
+
+import AppKit
+import Foundation
+
+/// Resolves the path to the cmux CLI. Used by both the launcher and the relay
+/// so they agree on where cmux is.
+enum CmuxBinary {
+    static let bundleId = "com.cmuxterm.app"
+
+    private static let lock = NSLock()
+    private static var cached: String?
+
+    /// Every location we know cmux's CLI can live at, in priority order.
+    /// Exposed so the diagnostics tab can show the user exactly where we looked.
+    ///
+    /// The first entry is derived from the *running* cmux app's own bundle —
+    /// the most robust source, since it finds cmux wherever it was installed
+    /// (including a Homebrew cask in /Applications, ~/Applications, or a
+    /// relocated/renamed copy). The static list covers cmux that's installed
+    /// but not currently running.
+    static var candidatePaths: [String] {
+        var paths: [String] = []
+
+        if let bundleURL = NSRunningApplication
+            .runningApplications(withBundleIdentifier: bundleId)
+            .first?.bundleURL {
+            paths.append(bundleURL.appendingPathComponent("Contents/Resources/bin/cmux").path)
+        }
+
+        let home = NSHomeDirectory()
+        paths += [
+            // Homebrew / user installs
+            "/opt/homebrew/bin/cmux",
+            "/usr/local/bin/cmux",
+            "\(home)/.local/bin/cmux",
+            // cmux.app bundle install
+            "/Applications/cmux.app/Contents/Resources/bin/cmux",
+            "\(home)/Applications/cmux.app/Contents/Resources/bin/cmux",
+        ]
+        return paths
+    }
+
+    /// First existing executable among the candidate paths, or nil if cmux
+    /// can't be found anywhere.
+    ///
+    /// A successful resolve is cached (the path rarely changes within a
+    /// session). The cache is re-validated with `isExecutableFile` on each
+    /// call, and a `nil` result is never cached — so opening/installing cmux
+    /// mid-session is picked up automatically without a restart. The
+    /// diagnostics "refresh" button can pass `forceRefresh: true` to re-scan.
+    ///
+    /// Thread-safe: `NSRunningApplication` and `FileManager` are usable from
+    /// any thread and the cache is `NSLock`-guarded, so this is callable from
+    /// the `nonisolated` contexts in `TerminalWriter`.
+    static func resolvedPath(forceRefresh: Bool = false) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if !forceRefresh,
+           let cached,
+           FileManager.default.isExecutableFile(atPath: cached) {
+            return cached
+        }
+
+        let found = candidatePaths.first { FileManager.default.isExecutableFile(atPath: $0) }
+        cached = found  // storing nil simply means "re-scan next time"
+        return found
+    }
+}

--- a/ClaudeIsland/Services/Sync/TerminalWriter.swift
+++ b/ClaudeIsland/Services/Sync/TerminalWriter.swift
@@ -118,6 +118,10 @@ final class TerminalWriter {
     /// the cmux connection diagnostic UI in System Settings.
     struct ConnectionProbe: Sendable {
         let cmuxBinaryInstalled: Bool
+        /// The exact path the relay resolved cmux to (or nil if not found).
+        /// Surfaced in the diagnostic row so a user can confirm *which* cmux
+        /// install the relay is using — the crux of the #49/#62 reports.
+        let cmuxBinaryPath: String?
         let accessibilityGranted: Bool
         let claudeSessionCount: Int
         /// Automation (AppleEvents) permission for the first running terminal.
@@ -136,7 +140,9 @@ final class TerminalWriter {
     /// phone message landing in cmux". Non-invasive — does not write to any
     /// terminal.
     func probeConnection() async -> ConnectionProbe {
-        let cmuxOk = FileManager.default.isExecutableFile(atPath: self.cmuxPath)
+        // Force a re-scan so the diagnostic reflects the live state (the user
+        // may have just installed/opened cmux and tapped "Refresh").
+        let cmuxResolved = CmuxBinary.resolvedPath(forceRefresh: true)
         let axOk = AXIsProcessTrusted()
         let procs = await listClaudeProcesses()
         var firstTarget: (workspaceId: String, surfaceId: String?)?
@@ -148,7 +154,8 @@ final class TerminalWriter {
         }
         let (autoOk, autoDetail) = probeAutomationPermission()
         return ConnectionProbe(
-            cmuxBinaryInstalled: cmuxOk,
+            cmuxBinaryInstalled: cmuxResolved != nil,
+            cmuxBinaryPath: cmuxResolved,
             accessibilityGranted: axOk,
             claudeSessionCount: procs.count,
             automationGranted: autoOk,
@@ -311,7 +318,7 @@ final class TerminalWriter {
         let termApp = session.terminalApp?.lowercased() ?? ""
 
         // Try cmux first (most precise)
-        if FileManager.default.isExecutableFile(atPath: cmuxPath) {
+        if cmuxPath != nil {
             if await sendViaCmux(text, session: session) {
                 return true
             }
@@ -1109,7 +1116,11 @@ final class TerminalWriter {
     /// previous raw Process.waitUntilExit could freeze the main thread when
     /// cmux became unresponsive (main cause of the "CodeIsland 卡死" reports).
     nonisolated private func cmuxRun(_ args: [String]) async -> String? {
-        let (out, ok) = await runShellWithTimeout(cmuxPath, args, timeout: 5.0)
+        guard let path = cmuxPath else {
+            DebugLogger.log("Cmux", "cmux binary not found in any known path — relay skipped")
+            return nil
+        }
+        let (out, ok) = await runShellWithTimeout(path, args, timeout: 5.0)
         return ok ? out : nil
     }
 
@@ -1381,9 +1392,12 @@ final class TerminalWriter {
 
 // MARK: - cmuxPath hoist for nonisolated access
 
-/// The nonisolated helpers above need access to `cmuxPath`, which is a
-/// stored instance property. Since cmuxPath is a constant, expose it via
-/// a nonisolated computed accessor.
+/// The nonisolated helpers above need to resolve the cmux CLI path. We delegate
+/// to the shared `CmuxBinary` resolver so the relay finds cmux at the SAME
+/// locations `LaunchService` does (Homebrew, ~/Applications, a running app's
+/// bundle, …) — not just the old hardcoded `/Applications/cmux.app` path that
+/// silently broke the relay for every non-standard install (issues #49, #62).
+/// Returns nil when cmux isn't installed anywhere.
 extension TerminalWriter {
-    nonisolated fileprivate var cmuxPath: String { "/Applications/cmux.app/Contents/Resources/bin/cmux" }
+    nonisolated fileprivate var cmuxPath: String? { CmuxBinary.resolvedPath() }
 }

--- a/ClaudeIsland/Services/Window/TerminalJumper.swift
+++ b/ClaudeIsland/Services/Window/TerminalJumper.swift
@@ -46,7 +46,7 @@ actor TerminalJumper {
         }
 
         if lower.contains("cmux") {
-            if await jumpViaCmux(cwd: cwd, sessionId: session.sessionId, tty: session.tty) { return true }
+            if await jumpViaCmux(cwd: cwd, sessionId: session.sessionId, tty: session.tty, surfaceId: session.cmuxSurfaceId) { return true }
         }
 
         if lower.contains("ghostty") {
@@ -79,7 +79,7 @@ actor TerminalJumper {
         //    the user was on iTerm, which could dispatch an AppleEvent to a
         //    missing cmux and hang/fail silently.
         if isRunning(bundleId: "com.cmuxterm.app") {
-            if await jumpViaCmux(cwd: cwd, sessionId: session.sessionId, tty: session.tty) { return true }
+            if await jumpViaCmux(cwd: cwd, sessionId: session.sessionId, tty: session.tty, surfaceId: session.cmuxSurfaceId) { return true }
         }
         if isRunning(bundleId: "com.mitchellh.ghostty") {
             if await jumpViaGhostty(cwd: cwd) { return true }
@@ -235,17 +235,28 @@ actor TerminalJumper {
 
     // MARK: - cmux (native AppleScript — `focus terminal`)
 
-    private func jumpViaCmux(cwd: String, sessionId: String? = nil, tty: String? = nil) async -> Bool {
+    private func jumpViaCmux(cwd: String, sessionId: String? = nil, tty: String? = nil, surfaceId: String? = nil) async -> Bool {
         guard CmuxTreeParser.isAvailable else { return false }
 
-        DebugLogger.log("Jump", "cmux jump: cwd=\(cwd)")
+        // Tier 1 (most robust): focus by the cmux surface ID the hook captured
+        // (CMUX_SURFACE_ID → SessionState.cmuxSurfaceId). Immune to the cwd
+        // drift — pane closed, `cd`'d away, symlink/trailing-slash mismatch —
+        // that makes the working-directory match miss (issue #62). If the ID is
+        // stale/unknown cmux just errors and we fall through to the cwd match.
+        if let surfaceId, !surfaceId.isEmpty {
+            DebugLogger.log("Jump", "cmux jump by surfaceId=\(surfaceId.prefix(8))…")
+            if await CmuxTreeParser.jump(panelId: surfaceId) {
+                return true
+            }
+        }
 
-        // One call: focus the terminal whose working directory matches
+        // Tier 2: focus the terminal whose working directory matches (guarded).
+        DebugLogger.log("Jump", "cmux jump: cwd=\(cwd)")
         if await CmuxTreeParser.jump(cwd: cwd) {
             return true
         }
 
-        // Fallback: just bring cmux to front
+        // Tier 3: just bring cmux to front.
         DebugLogger.log("Jump", "cmux focus failed, activating cmux app")
         await bringCmuxToFront()
         return true

--- a/ClaudeIsland/UI/Views/SystemSettingsView.swift
+++ b/ClaudeIsland/UI/Views/SystemSettingsView.swift
@@ -1535,7 +1535,9 @@ private struct CmuxConnectionTab: View {
                     icon: "terminal.fill",
                     title: L10n.cmuxBinaryRow,
                     ok: probe?.cmuxBinaryInstalled ?? false,
-                    detail: (probe?.cmuxBinaryInstalled ?? false) ? L10n.cmuxBinaryFound : L10n.cmuxBinaryMissing
+                    detail: (probe?.cmuxBinaryInstalled ?? false)
+                        ? (probe?.cmuxBinaryPath ?? L10n.cmuxBinaryFound)
+                        : L10n.cmuxBinaryMissing
                 )
                 statusRow(
                     icon: "accessibility",


### PR DESCRIPTION
## Problem

Two cmux symptoms reported in #49 and #62, both real:

- **#49** "brew 安装的 Cmux…发消息没有任何反应" — phone messages silently do nothing.
- **#62** "cmux 连不上，总是失败，权限都给了" — "go to terminal" intermittently fails; logs show `cmux got an error … Invalid index. (-1719)`.

### Root cause 1 — inconsistent cmux binary discovery (#49)

`TerminalWriter` hardcoded the cmux CLI to `/Applications/cmux.app/Contents/Resources/bin/cmux`, while `LaunchService.findCmuxBinary()` probed **five** paths (Homebrew, `/usr/local`, `~/.local`, `~/Applications`, …). So a user whose cmux lives anywhere else could **launch** sessions fine but every **relay** (send / control-key / read-screen) silently no-op'd through `cmuxRun()` — and the diagnostics tab wrongly reported "cmux not installed". The bug is invisible on a standard `/Applications` install (why it slipped through).

### Root cause 2 — fragile jump (#62)

`jumpViaCmux` matched only by exact `first terminal whose working directory is "X"`, which throws `-1719 Invalid index` whenever **no pane currently has that cwd** (pane closed, `cd`'d away, symlink/trailing-slash mismatch). The captured `CMUX_SURFACE_ID` (→ `SessionState.cmuxSurfaceId`, populated in `SessionStore`) and an ID-based focus method (`CmuxTreeParser.jump(panelId:)`) already existed but were never used for jumping.

## Changes

- **New `CmuxBinary` resolver** (`Services/Shared/CmuxBinary.swift`): single source of truth. Checks the **running cmux app's own bundle** first (finds cmux wherever installed), then the same static candidate list as before. Success-cached + live-revalidated; `nil` never cached (so installing/opening cmux mid-session is picked up). Thread-safe → callable from `TerminalWriter`'s `nonisolated` contexts. `TerminalWriter.cmuxPath` and `LaunchService.findCmuxBinary()` both delegate to it.
- **3-tier `jumpViaCmux`**: (1) focus by cmux **surface ID** — immune to cwd drift; (2) **guarded** cwd match; (3) activate app. `CmuxTreeParser.jump(cwd:)` now uses a `count`-guarded AppleScript (returns a sentinel instead of throwing `-1719`) and a **normalized** path (`standardizedFileURL`). If the surface ID is stale, cmux just errors and we fall through cleanly — no regression.
- **Diagnostics**: the cmux-binary row now shows the **resolved path** (so a user can confirm *which* cmux the relay uses); the "missing" string lists the real search locations instead of the stale `/Applications/cmux.app`.

## Test

- `xcodebuild build -scheme ClaudeIsland -configuration Debug` → **BUILD SUCCEEDED** (incl. the new file via the synchronized file group).
- Resolver algorithm **verified against the real filesystem**: with cmux running, it resolves via the app bundle to the actual install; the full candidate list (incl. `/opt/homebrew/bin/cmux`) is enumerated with live `isExecutableFile` checks.
- ⚠️ **Not** verified against a live Homebrew cmux install (none on the build machine) nor a live `-1719` repro (needs a failing user's environment). The `cmux_surface_id`↔AppleScript `terminal id` mapping is the principled one per cmux's sdef (`terminal.id` = "Stable ID for this terminal panel"); if it ever mismatches, the jump degrades gracefully to the cwd tier.
- Note: this repo has **no XCTest target** (only the app target builds), so the existing `*Tests.swift` files aren't run by `xcodebuild` and no unit test was added (it wouldn't execute).

Refs #49, #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)