### PR TITLE
feat(usage-bar): cross-model token-consumption meter + Catppuccin theme

### DIFF
--- a/ClaudeIsland/Core/Localization.swift
+++ b/ClaudeIsland/Core/Localization.swift
@@ -644,6 +644,7 @@ enum L10n {
     static var notchThemeRetroArcade: String { tr("Retro Arcade", "复古游戏机") }
     static var notchThemeHighContrast: String { tr("High Contrast", "高对比") }
     static var notchThemeSakura: String { tr("Pink Mist", "粉雾") }
+    static var notchThemeCatppuccin: String { tr("Catppuccin", "Catppuccin") }
     static var notchHoverSpeed: String { tr("Hover Speed", "展开速度") }
     static var notchHoverInstant: String { tr("Fast", "即时") }
     static var notchHoverNormal: String { tr("1s", "1秒") }
@@ -666,6 +667,7 @@ enum L10n {
     static var usageBarModeAlert: String { tr("Alert", "警戒") }
     static var usageBarModeCompact: String { tr("Compact", "紧凑") }
     static var usageBarModeTime: String { tr("Time", "时间") }
+    static var usageBarModeTokens: String { tr("Tokens", "Token") }
     static var usageBarModeAutoDescription: String {
         tr("< 60% Compact · ≥ 60% Alert · ≥ 80% Red Pulse",
            "< 60% 紧凑 · ≥ 60% 警戒 · ≥ 80% 红色脉冲")
@@ -678,6 +680,22 @@ enum L10n {
     }
     static var usageBarModeTimeDescription: String {
         tr("Emphasize remaining time + ring", "突出剩余时间 + 环形")
+    }
+    static var usageBarModeTokensDescription: String {
+        tr("Today's real token use, all models — works even at 0% plan",
+           "今日真实 token 消耗（全模型）· plan 显示 0% 也能看")
+    }
+
+    // Token usage bar
+    static var usageBarTokensToday: String { tr("TODAY", "今日") }
+    static func usageBarTokensCached(_ n: String) -> String {
+        tr("\(n) cached", "\(n) 缓存")
+    }
+    static func usageBarTokensMore(_ n: Int) -> String {
+        tr("+\(n) more models", "另 \(n) 个模型")
+    }
+    static var usageBarTokensEmpty: String {
+        tr("No token activity today", "今日暂无 token 记录")
     }
 
     // Per-provider sub-toggles
@@ -711,6 +729,7 @@ enum L10n {
         case NotchThemeID.retroArcade.rawValue: return notchThemeRetroArcade
         case NotchThemeID.highContrast.rawValue: return notchThemeHighContrast
         case NotchThemeID.sakura.rawValue: return notchThemeSakura
+        case NotchThemeID.catppuccin.rawValue: return notchThemeCatppuccin
         default: return ThemeRegistry.shared.displayName(for: id)
         }
     }

--- a/ClaudeIsland/Models/NotchCustomization.swift
+++ b/ClaudeIsland/Models/NotchCustomization.swift
@@ -207,6 +207,7 @@ struct NotchThemeID: RawRepresentable, Codable, Hashable, Identifiable {
     static let retroArcade = NotchThemeID(rawValue: "retroArcade")
     static let highContrast = NotchThemeID(rawValue: "highContrast")
     static let sakura = NotchThemeID(rawValue: "sakura")
+    static let catppuccin = NotchThemeID(rawValue: "catppuccin")
 }
 
 /// Four-step relative font scale. String raw values for stable
@@ -255,11 +256,19 @@ enum HardwareNotchMode: String, Codable {
 ///   reset time hint. Information-dense, low-attention.
 /// - `time`: emphasize remaining time before reset, with a small ring
 ///   showing the percentage.
+/// - `tokens`: a different DATA SOURCE entirely — instead of the plan
+///   rate-limit %, show today's actual token consumption read from the local
+///   CLI transcripts (~/.claude + ~/.codex), aggregated across all models.
+///   Works even when the plan % reads 0% (Spark / proxied / third-party relay),
+///   because token counts come from the local transcript, not the rate-limit
+///   API. When selected, a single unified bar replaces the per-provider plan
+///   bars. See TokenUsage.swift.
 enum UsageBarDisplayMode: String, Codable, CaseIterable, Identifiable {
     case auto
     case alert
     case compact
     case time
+    case tokens
 
     var id: String { rawValue }
 }

--- a/ClaudeIsland/Models/ThemeRegistry.swift
+++ b/ClaudeIsland/Models/ThemeRegistry.swift
@@ -131,12 +131,12 @@ final class ThemeRegistry: ObservableObject {
             previewIdleLabelZH: "空闲",
             prefersUppercasePreviewLabel: false,
             tokens: ThemeTokens(
-                chrome: .init(background: .init(hex: "000000"), overlay: .init(hex: "1A1A1A"), border: .init(hex: "2A2A2A")),
-                text: .init(primary: .white, secondary: .init(hex: "FFFFFF"), muted: .init(hex: "9A9A9A"), inverse: .black),
-                status: .init(idle: .init(hex: "CAFF00"), working: .init(hex: "66E8F8"), needsYou: .init(hex: "F59E0B"), error: .init(hex: "EF4444"), done: .init(hex: "4ADE80"), thinking: .init(hex: "A78BFA")),
-                badges: .init(agentText: .init(hex: "60A5FA"), agentFill: .init(hex: "1E3A8A"), terminalText: .init(hex: "93C5FD"), terminalFill: .init(hex: "1E3A8A"), subduedText: .init(hex: "FFFFFF"), subduedFill: .init(hex: "262626")),
-                usage: .init(text: .init(hex: "FFFFFF"), track: .init(hex: "2A2A2A"), fill: .init(hex: "4ADE80"), border: .init(hex: "2A2A2A")),
-                chat: .init(bodyText: .white, secondaryText: .init(hex: "D1D5DB"), bubbleText: .white, bubbleFill: .init(hex: "2F2F2F"), assistantDot: .init(hex: "FFFFFF"))
+                chrome: .init(background: .init(hex: "0A0A0B"), overlay: .init(hex: "191919"), border: .init(hex: "2A2A2C")),
+                text: .init(primary: .init(hex: "EDEDEE"), secondary: .init(hex: "C7C7CB"), muted: .init(hex: "8B8B90"), inverse: .init(hex: "0A0A0B")),
+                status: .init(idle: .init(hex: "CCFF00"), working: .init(hex: "67E8F9"), needsYou: .init(hex: "FBBF24"), error: .init(hex: "F87171"), done: .init(hex: "4ADE80"), thinking: .init(hex: "B794F6")),
+                badges: .init(agentText: .init(hex: "7DB4FF"), agentFill: .init(hex: "1E3A8A"), terminalText: .init(hex: "A8CBFF"), terminalFill: .init(hex: "1E3A8A"), subduedText: .init(hex: "E8E8EA"), subduedFill: .init(hex: "242428")),
+                usage: .init(text: .init(hex: "F4F4F5"), track: .init(hex: "26262A"), fill: .init(hex: "A3E635"), border: .init(hex: "2A2A2C")),
+                chat: .init(bodyText: .init(hex: "EDEDEE"), secondaryText: .init(hex: "B8B8BD"), bubbleText: .init(hex: "F4F4F5"), bubbleFill: .init(hex: "2E2E32"), assistantDot: .init(hex: "EDEDEE"))
             ),
             source: .builtIn
         ),
@@ -147,12 +147,12 @@ final class ThemeRegistry: ObservableObject {
             previewIdleLabelZH: "空闲",
             prefersUppercasePreviewLabel: false,
             tokens: ThemeTokens(
-                chrome: .init(background: .init(hex: "0D1F14"), overlay: .init(hex: "163020"), border: .init(hex: "294534")),
-                text: .init(primary: .init(hex: "E8F5E9"), secondary: .init(hex: "B8D0BE"), muted: .init(hex: "8BA896"), inverse: .black),
-                status: .init(idle: .init(hex: "7CC85A"), working: .init(hex: "66E8F8"), needsYou: .init(hex: "F59E0B"), error: .init(hex: "EF4444"), done: .init(hex: "4ADE80"), thinking: .init(hex: "A78BFA")),
-                badges: .init(agentText: .init(hex: "CFE9D7"), agentFill: .init(hex: "23422E"), terminalText: .init(hex: "A8DAB7"), terminalFill: .init(hex: "1B3525"), subduedText: .init(hex: "D5E6DA"), subduedFill: .init(hex: "1B3525")),
-                usage: .init(text: .init(hex: "DCEFE1"), track: .init(hex: "284033"), fill: .init(hex: "7CC85A"), border: .init(hex: "284033")),
-                chat: .init(bodyText: .init(hex: "E8F5E9"), secondaryText: .init(hex: "B8D0BE"), bubbleText: .init(hex: "E8F5E9"), bubbleFill: .init(hex: "23422E"), assistantDot: .init(hex: "CFE9D7"))
+                chrome: .init(background: .init(hex: "0A1C12"), overlay: .init(hex: "122B1C"), border: .init(hex: "2B4A37")),
+                text: .init(primary: .init(hex: "EAF6EB"), secondary: .init(hex: "B9D3C0"), muted: .init(hex: "8DAC98"), inverse: .init(hex: "07120B")),
+                status: .init(idle: .init(hex: "86D957"), working: .init(hex: "5BE0D8"), needsYou: .init(hex: "F5A524"), error: .init(hex: "F0584F"), done: .init(hex: "50DF82"), thinking: .init(hex: "A78BFA")),
+                badges: .init(agentText: .init(hex: "D4ECDB"), agentFill: .init(hex: "224A30"), terminalText: .init(hex: "A9DEB8"), terminalFill: .init(hex: "173220"), subduedText: .init(hex: "D7E8DC"), subduedFill: .init(hex: "173220")),
+                usage: .init(text: .init(hex: "DDEFE2"), track: .init(hex: "2A4937"), fill: .init(hex: "86D957"), border: .init(hex: "2A4937")),
+                chat: .init(bodyText: .init(hex: "EAF6EB"), secondaryText: .init(hex: "B9D3C0"), bubbleText: .init(hex: "EAF6EB"), bubbleFill: .init(hex: "224A30"), assistantDot: .init(hex: "D4ECDB"))
             ),
             source: .builtIn
         ),
@@ -163,12 +163,12 @@ final class ThemeRegistry: ObservableObject {
             previewIdleLabelZH: "IDLE_",
             prefersUppercasePreviewLabel: true,
             tokens: ThemeTokens(
-                chrome: .init(background: .init(hex: "070B1A"), overlay: .init(hex: "111A38"), border: .init(hex: "1D2A59")),
-                text: .init(primary: .init(hex: "F7F3FF"), secondary: .init(hex: "C7B6F8"), muted: .init(hex: "7DA6D9"), inverse: .black),
-                status: .init(idle: .init(hex: "FF2FAE"), working: .init(hex: "00E5FF"), needsYou: .init(hex: "FFB703"), error: .init(hex: "FF4D6D"), done: .init(hex: "C084FC"), thinking: .init(hex: "7C3AED")),
-                badges: .init(agentText: .init(hex: "FF7AC8"), agentFill: .init(hex: "2A1144"), terminalText: .init(hex: "6CF2FF"), terminalFill: .init(hex: "0D2C45"), subduedText: .init(hex: "D8CCFF"), subduedFill: .init(hex: "151F46")),
-                usage: .init(text: .init(hex: "E8DEFF"), track: .init(hex: "162347"), fill: .init(hex: "FF2FAE"), border: .init(hex: "24356A")),
-                chat: .init(bodyText: .init(hex: "F7F3FF"), secondaryText: .init(hex: "C7B6F8"), bubbleText: .init(hex: "F7F3FF"), bubbleFill: .init(hex: "141D3D"), assistantDot: .init(hex: "00E5FF"))
+                chrome: .init(background: .init(hex: "04060F"), overlay: .init(hex: "0E1530"), border: .init(hex: "23306B")),
+                text: .init(primary: .init(hex: "F8F4FF"), secondary: .init(hex: "C9B8FF"), muted: .init(hex: "7FA8E0"), inverse: .init(hex: "000000")),
+                status: .init(idle: .init(hex: "FF1FB0"), working: .init(hex: "1FF0FF"), needsYou: .init(hex: "FFB300"), error: .init(hex: "FF3D5E"), done: .init(hex: "5CF2C0"), thinking: .init(hex: "A36BFF")),
+                badges: .init(agentText: .init(hex: "FF8FD4"), agentFill: .init(hex: "2B0F4A"), terminalText: .init(hex: "7DF6FF"), terminalFill: .init(hex: "06304C"), subduedText: .init(hex: "DCD0FF"), subduedFill: .init(hex: "141F4A")),
+                usage: .init(text: .init(hex: "EBE2FF"), track: .init(hex: "17244A"), fill: .init(hex: "FF1FB0"), border: .init(hex: "2A3D78")),
+                chat: .init(bodyText: .init(hex: "F8F4FF"), secondaryText: .init(hex: "C9B8FF"), bubbleText: .init(hex: "F8F4FF"), bubbleFill: .init(hex: "121A3D"), assistantDot: .init(hex: "1FF0FF"))
             ),
             source: .builtIn
         ),
@@ -179,12 +179,12 @@ final class ThemeRegistry: ObservableObject {
             previewIdleLabelZH: "静候",
             prefersUppercasePreviewLabel: false,
             tokens: ThemeTokens(
-                chrome: .init(background: .init(hex: "FFF4E8"), overlay: .init(hex: "F6E6D3"), border: .init(hex: "E8D1BD")),
-                text: .init(primary: .init(hex: "4A2618"), secondary: .init(hex: "6D4330"), muted: .init(hex: "A06850"), inverse: .white),
-                status: .init(idle: .init(hex: "E8552A"), working: .init(hex: "0F766E"), needsYou: .init(hex: "B45309"), error: .init(hex: "B91C1C"), done: .init(hex: "15803D"), thinking: .init(hex: "7C3AED")),
-                badges: .init(agentText: .init(hex: "7C2D12"), agentFill: .init(hex: "F7D7BF"), terminalText: .init(hex: "5B4636"), terminalFill: .init(hex: "F1DECF"), subduedText: .init(hex: "5B4636"), subduedFill: .init(hex: "F1DECF")),
-                usage: .init(text: .init(hex: "4A2618"), track: .init(hex: "E8D1BD"), fill: .init(hex: "E8552A"), border: .init(hex: "E8D1BD")),
-                chat: .init(bodyText: .init(hex: "4A2618"), secondaryText: .init(hex: "6D4330"), bubbleText: .init(hex: "4A2618"), bubbleFill: .init(hex: "F6E6D3"), assistantDot: .init(hex: "4A2618"))
+                chrome: .init(background: .init(hex: "FFEFDC"), overlay: .init(hex: "FBE0C6"), border: .init(hex: "EDC9A8")),
+                text: .init(primary: .init(hex: "47210F"), secondary: .init(hex: "6B3C25"), muted: .init(hex: "9C5E3F"), inverse: .init(hex: "FFFFFF")),
+                status: .init(idle: .init(hex: "D9491E"), working: .init(hex: "0E7C6E"), needsYou: .init(hex: "A85A06"), error: .init(hex: "AE1A1A"), done: .init(hex: "197A38"), thinking: .init(hex: "8B3FD6")),
+                badges: .init(agentText: .init(hex: "7A2E10"), agentFill: .init(hex: "FAD2B0"), terminalText: .init(hex: "53382A"), terminalFill: .init(hex: "F4DBC4"), subduedText: .init(hex: "53382A"), subduedFill: .init(hex: "F4DBC4")),
+                usage: .init(text: .init(hex: "47210F"), track: .init(hex: "EDC9A8"), fill: .init(hex: "D9491E"), border: .init(hex: "EDC9A8")),
+                chat: .init(bodyText: .init(hex: "47210F"), secondaryText: .init(hex: "6B3C25"), bubbleText: .init(hex: "47210F"), bubbleFill: .init(hex: "FBE0C6"), assistantDot: .init(hex: "D9491E"))
             ),
             source: .builtIn
         ),
@@ -195,12 +195,12 @@ final class ThemeRegistry: ObservableObject {
             previewIdleLabelZH: "IDLE",
             prefersUppercasePreviewLabel: true,
             tokens: ThemeTokens(
-                chrome: .init(background: .init(hex: "10B981"), overlay: .init(hex: "6EE7B7"), border: .init(hex: "065F46")),
-                text: .init(primary: .black, secondary: .black, muted: .black, inverse: .white),
-                status: .init(idle: .init(hex: "064E3B"), working: .init(hex: "065F46"), needsYou: .init(hex: "92400E"), error: .init(hex: "991B1B"), done: .init(hex: "14532D"), thinking: .init(hex: "312E81")),
-                badges: .init(agentText: .black, agentFill: .init(hex: "A7F3D0"), terminalText: .black, terminalFill: .init(hex: "6EE7B7"), subduedText: .black, subduedFill: .init(hex: "86EFAC")),
-                usage: .init(text: .black, track: .init(hex: "A7F3D0"), fill: .init(hex: "064E3B"), border: .init(hex: "065F46")),
-                chat: .init(bodyText: .black, secondaryText: .black, bubbleText: .black, bubbleFill: .init(hex: "A7F3D0"), assistantDot: .init(hex: "064E3B"))
+                chrome: .init(background: .init(hex: "34C77B"), overlay: .init(hex: "6FE0A8"), border: .init(hex: "0B5138")),
+                text: .init(primary: .init(hex: "0C2E1E"), secondary: .init(hex: "124A30"), muted: .init(hex: "18583A"), inverse: .init(hex: "FFFFFF")),
+                status: .init(idle: .init(hex: "064E3B"), working: .init(hex: "0B5138"), needsYou: .init(hex: "8A4B0E"), error: .init(hex: "A01818"), done: .init(hex: "117A3D"), thinking: .init(hex: "3B2E91")),
+                badges: .init(agentText: .init(hex: "0C2E1E"), agentFill: .init(hex: "9DEFC4"), terminalText: .init(hex: "0C2E1E"), terminalFill: .init(hex: "6FE0A8"), subduedText: .init(hex: "0C2E1E"), subduedFill: .init(hex: "7FE8B4")),
+                usage: .init(text: .init(hex: "0C2E1E"), track: .init(hex: "9DEFC4"), fill: .init(hex: "064E3B"), border: .init(hex: "0B5138")),
+                chat: .init(bodyText: .init(hex: "0C2E1E"), secondaryText: .init(hex: "124A30"), bubbleText: .init(hex: "0C2E1E"), bubbleFill: .init(hex: "9DEFC4"), assistantDot: .init(hex: "064E3B"))
             ),
             source: .builtIn
         ),
@@ -211,12 +211,12 @@ final class ThemeRegistry: ObservableObject {
             previewIdleLabelZH: "空闲",
             prefersUppercasePreviewLabel: false,
             tokens: ThemeTokens(
-                chrome: .init(background: .init(hex: "000000"), overlay: .init(hex: "111111"), border: .init(hex: "FFFFFF")),
-                text: .init(primary: .white, secondary: .white, muted: .white, inverse: .black),
-                status: .init(idle: .init(hex: "FFE600"), working: .init(hex: "66E8F8"), needsYou: .init(hex: "FFE600"), error: .init(hex: "FF4D4D"), done: .init(hex: "4ADE80"), thinking: .init(hex: "A78BFA")),
-                badges: .init(agentText: .white, agentFill: .init(hex: "000000"), terminalText: .white, terminalFill: .init(hex: "000000"), subduedText: .white, subduedFill: .init(hex: "000000")),
-                usage: .init(text: .white, track: .init(hex: "333333"), fill: .init(hex: "FFE600"), border: .white),
-                chat: .init(bodyText: .white, secondaryText: .white, bubbleText: .white, bubbleFill: .init(hex: "111111"), assistantDot: .white)
+                chrome: .init(background: .init(hex: "000000"), overlay: .init(hex: "121212"), border: .init(hex: "FFFFFF")),
+                text: .init(primary: .init(hex: "FFFFFF"), secondary: .init(hex: "E6E6E6"), muted: .init(hex: "BFBFBF"), inverse: .init(hex: "000000")),
+                status: .init(idle: .init(hex: "FFD400"), working: .init(hex: "5EE7F5"), needsYou: .init(hex: "FFA51F"), error: .init(hex: "FF5C57"), done: .init(hex: "3DE07A"), thinking: .init(hex: "B695FF")),
+                badges: .init(agentText: .init(hex: "FFFFFF"), agentFill: .init(hex: "000000"), terminalText: .init(hex: "FFFFFF"), terminalFill: .init(hex: "000000"), subduedText: .init(hex: "FFFFFF"), subduedFill: .init(hex: "000000")),
+                usage: .init(text: .init(hex: "FFFFFF"), track: .init(hex: "333333"), fill: .init(hex: "FFD400"), border: .init(hex: "FFFFFF")),
+                chat: .init(bodyText: .init(hex: "FFFFFF"), secondaryText: .init(hex: "C9C9C9"), bubbleText: .init(hex: "FFFFFF"), bubbleFill: .init(hex: "161616"), assistantDot: .init(hex: "FFD400"))
             ),
             source: .builtIn
         ),
@@ -227,12 +227,28 @@ final class ThemeRegistry: ObservableObject {
             previewIdleLabelZH: "小憩",
             prefersUppercasePreviewLabel: false,
             tokens: ThemeTokens(
-                chrome: .init(background: .init(hex: "FFF4FB"), overlay: .init(hex: "FFE3F2"), border: .init(hex: "F6BDD9")),
-                text: .init(primary: .init(hex: "7A3558"), secondary: .init(hex: "A2557D"), muted: .init(hex: "C27AA1"), inverse: .white),
-                status: .init(idle: .init(hex: "F472B6"), working: .init(hex: "F9A8D4"), needsYou: .init(hex: "FB7185"), error: .init(hex: "E11D48"), done: .init(hex: "EC4899"), thinking: .init(hex: "C084FC")),
-                badges: .init(agentText: .init(hex: "8F3A66"), agentFill: .init(hex: "FFD6EB"), terminalText: .init(hex: "7A3558"), terminalFill: .init(hex: "FFF0F8"), subduedText: .init(hex: "7A3558"), subduedFill: .init(hex: "FFE7F4")),
-                usage: .init(text: .init(hex: "7A3558"), track: .init(hex: "FAD7E8"), fill: .init(hex: "F472B6"), border: .init(hex: "F3B7D2")),
-                chat: .init(bodyText: .init(hex: "7A3558"), secondaryText: .init(hex: "A2557D"), bubbleText: .init(hex: "7A3558"), bubbleFill: .init(hex: "FFF0F8"), assistantDot: .init(hex: "C2417A"))
+                chrome: .init(background: .init(hex: "FDF2F8"), overlay: .init(hex: "FCE0EE"), border: .init(hex: "F3BBD6")),
+                text: .init(primary: .init(hex: "6E2C4E"), secondary: .init(hex: "9A4A74"), muted: .init(hex: "B06A92"), inverse: .init(hex: "FFFFFF")),
+                status: .init(idle: .init(hex: "DB2777"), working: .init(hex: "F9A8D4"), needsYou: .init(hex: "D98324"), error: .init(hex: "D6395C"), done: .init(hex: "2E9E6E"), thinking: .init(hex: "B266E0")),
+                badges: .init(agentText: .init(hex: "8A2F5C"), agentFill: .init(hex: "FBD0E6"), terminalText: .init(hex: "6E2C4E"), terminalFill: .init(hex: "FDEAF4"), subduedText: .init(hex: "6E2C4E"), subduedFill: .init(hex: "FBE2F0")),
+                usage: .init(text: .init(hex: "6E2C4E"), track: .init(hex: "F7C9DF"), fill: .init(hex: "DB2777"), border: .init(hex: "F0B4D0")),
+                chat: .init(bodyText: .init(hex: "6E2C4E"), secondaryText: .init(hex: "9A4A74"), bubbleText: .init(hex: "6E2C4E"), bubbleFill: .init(hex: "FDEAF4"), assistantDot: .init(hex: "DB2777"))
+            ),
+            source: .builtIn
+        ),
+        ThemeDescriptor(
+            id: .catppuccin,
+            fallbackDisplayName: "Catppuccin",
+            previewIdleLabelEN: "purring",
+            previewIdleLabelZH: "打盹",
+            prefersUppercasePreviewLabel: false,
+            tokens: ThemeTokens(
+                chrome: .init(background: .init(hex: "1E1E2E"), overlay: .init(hex: "313244"), border: .init(hex: "45475A")),
+                text: .init(primary: .init(hex: "CDD6F4"), secondary: .init(hex: "BAC2DE"), muted: .init(hex: "7F849C"), inverse: .init(hex: "11111B")),
+                status: .init(idle: .init(hex: "CBA6F7"), working: .init(hex: "89DCEB"), needsYou: .init(hex: "FAB387"), error: .init(hex: "F38BA8"), done: .init(hex: "A6E3A1"), thinking: .init(hex: "B4BEFE")),
+                badges: .init(agentText: .init(hex: "89B4FA"), agentFill: .init(hex: "313244"), terminalText: .init(hex: "94E2D5"), terminalFill: .init(hex: "313244"), subduedText: .init(hex: "A6ADC8"), subduedFill: .init(hex: "45475A")),
+                usage: .init(text: .init(hex: "CDD6F4"), track: .init(hex: "45475A"), fill: .init(hex: "A6E3A1"), border: .init(hex: "45475A")),
+                chat: .init(bodyText: .init(hex: "CDD6F4"), secondaryText: .init(hex: "BAC2DE"), bubbleText: .init(hex: "CDD6F4"), bubbleFill: .init(hex: "313244"), assistantDot: .init(hex: "CBA6F7"))
             ),
             source: .builtIn
         ),

--- a/ClaudeIsland/Services/Session/TokenUsage.swift
+++ b/ClaudeIsland/Services/Session/TokenUsage.swift
@@ -1,0 +1,331 @@
+//
+//  TokenUsage.swift
+//  ClaudeIsland
+//
+//  Local-transcript token meter. Aggregates today's token consumption across
+//  ALL models by reading the JSONL transcripts the official CLIs write:
+//    - Claude Code:  ~/.claude/projects/<slug>/<session-uuid>.jsonl
+//    - Codex CLI:    ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+//
+//  Independent of subscription plan / rate-limit API: works for Free/Pro/Max,
+//  for Spark, and for proxied/relayed setups (custom model_provider /
+//  ANTHROPIC_BASE_URL) — the CLI writes the transcript locally regardless of
+//  where requests are routed. It does NOT see tools that write neither file
+//  (custom API scripts, Cursor, web clients, or SSH-remote sessions).
+//
+//  Models are auto-discovered from the data (message.model / limit_name).
+//
+
+import Combine
+import Foundation
+
+// MARK: - Models
+
+/// Per-model token totals for the current day, normalized across providers.
+/// "Billable" = input + output (charged at full rate). Cache-read tokens are
+/// tracked separately because they are nearly free and would otherwise inflate
+/// the headline by 50-100x.
+struct TokenModelUsage: Equatable, Codable, Sendable, Identifiable {
+    var model: String
+    var provider: String       // "Claude" | "Codex"
+    var billableInput: Int
+    var output: Int
+    var cacheRead: Int
+    var cacheWrite: Int
+
+    var id: String { provider + "/" + model }
+    var billable: Int { billableInput + output }
+    var cache: Int { cacheRead + cacheWrite }
+    var total: Int { billable + cache }
+}
+
+struct TokenUsageSnapshot: Equatable, Codable, Sendable {
+    var models: [TokenModelUsage]
+    var capturedAt: Date?
+    var dayStart: Date?
+
+    var totalBillable: Int { models.reduce(0) { $0 + $1.billable } }
+    var totalCache: Int { models.reduce(0) { $0 + $1.cache } }
+    var isEmpty: Bool { models.isEmpty }
+}
+
+/// File identity used for cheap change-detection between poll cycles.
+struct FileMeta: Equatable, Sendable {
+    var size: Int
+    var mtime: Date
+}
+
+/// Loader output: the snapshot plus the file-metadata fingerprint that produced
+/// it, so the next cycle can skip parsing entirely when nothing changed.
+struct TokenLoadResult: Sendable {
+    var snapshot: TokenUsageSnapshot
+    var meta: [String: FileMeta]
+}
+
+// MARK: - Monitor
+
+@MainActor
+final class TokenUsageMonitor: ObservableObject {
+    static let shared = TokenUsageMonitor()
+
+    @Published private(set) var snapshot: TokenUsageSnapshot?
+    @Published private(set) var isLoading = false
+
+    private var refreshTimer: Timer?
+    /// File fingerprint from the last successful parse — lets us skip a cycle
+    /// when no transcript changed (idle = stat-only, no content read).
+    private var lastMeta: [String: FileMeta] = [:]
+
+    private init() {}
+
+    func start() {
+        guard refreshTimer == nil else { return }
+        refreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.refresh() }
+        }
+        Task { await refresh() }
+    }
+
+    func stop() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+        snapshot = nil
+        lastMeta = [:]
+    }
+
+    func refresh() async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        let prior = lastMeta
+        // Scan + parse off the main thread. The loader is a pure function
+        // (prior fingerprint in → result out); no shared mutable state.
+        let result = await Task.detached(priority: .utility) {
+            TokenUsageLoader.load(prior: prior)
+        }.value
+        if let result {
+            snapshot = result.snapshot
+            lastMeta = result.meta
+        }
+        // result == nil → nothing changed since last cycle; keep current snapshot.
+    }
+}
+
+// MARK: - Loader
+
+enum TokenUsageLoader {
+    static var claudeProjectsURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+    }
+    static var codexSessionsURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex/sessions", isDirectory: true)
+    }
+
+    /// Returns nil when no qualifying file changed vs `prior` (caller keeps its
+    /// existing snapshot). Otherwise parses today's transcripts and returns the
+    /// fresh snapshot + file fingerprint.
+    static func load(
+        prior: [String: FileMeta] = [:],
+        now: Date = Date(),
+        claudeRoot: URL? = nil,
+        codexRoot: URL? = nil,
+        calendar: Calendar = .current,
+        fileManager: FileManager = .default
+    ) -> TokenLoadResult? {
+        let dayStart = calendar.startOfDay(for: now)
+        let claudeFiles = jsonlFiles(in: claudeRoot ?? claudeProjectsURL,
+                                     modifiedOnOrAfter: dayStart, fileManager: fileManager)
+        let codexFiles = jsonlFiles(in: codexRoot ?? codexSessionsURL,
+                                    modifiedOnOrAfter: dayStart, prefix: "rollout-",
+                                    fileManager: fileManager)
+        var meta: [String: FileMeta] = [:]
+        for (url, m) in claudeFiles { meta[url.path] = m }
+        for (url, m) in codexFiles { meta[url.path] = m }
+
+        // Change-detection: identical fingerprint → skip the content read.
+        // (prior empty = first run → always parse.)
+        if !prior.isEmpty && meta == prior {
+            return nil
+        }
+
+        var acc: [String: TokenModelUsage] = [:]
+        // Dedup Claude by logical message id ACROSS all files: a tool-use turn
+        // is written once per content block, every line carrying the identical
+        // message.usage. Summing per line over-counts 2-4x. Forked/resumed
+        // sessions can repeat an id across files too, so the set spans the load.
+        var seenClaudeIds = Set<String>()
+        for (url, _) in claudeFiles {
+            parseClaude(url, into: &acc, seen: &seenClaudeIds, dayStart: dayStart)
+        }
+        for (url, _) in codexFiles {
+            parseCodex(url, into: &acc, dayStart: dayStart)
+        }
+        let models = acc.values
+            .filter { $0.total > 0 }
+            .sorted { $0.billable > $1.billable }
+        let snapshot = TokenUsageSnapshot(models: models, capturedAt: now, dayStart: dayStart)
+        return TokenLoadResult(snapshot: snapshot, meta: meta)
+    }
+
+    // MARK: Claude
+
+    private static func parseClaude(
+        _ url: URL, into acc: inout [String: TokenModelUsage],
+        seen: inout Set<String>, dayStart: Date
+    ) {
+        forEachLine(in: url) { line in
+            guard let obj = jsonObject(line),
+                  obj["type"] as? String == "assistant",
+                  let ts = isoDate(obj["timestamp"]), ts >= dayStart,
+                  let message = obj["message"] as? [String: Any],
+                  let usage = message["usage"] as? [String: Any] else { return }
+            let model = (message["model"] as? String) ?? "unknown"
+            if model == "<synthetic>" { return }
+            // Dedup: one logical assistant message = one count, no matter how
+            // many content-block lines repeat it.
+            let mid = (message["id"] as? String) ?? (obj["requestId"] as? String)
+            if let mid {
+                if seen.contains(mid) { return }
+                seen.insert(mid)
+            }
+            let key = "Claude/" + model
+            var entry = acc[key]
+                ?? TokenModelUsage(model: model, provider: "Claude",
+                                   billableInput: 0, output: 0, cacheRead: 0, cacheWrite: 0)
+            entry.billableInput += intVal(usage["input_tokens"])
+            entry.output += intVal(usage["output_tokens"])
+            entry.cacheRead += intVal(usage["cache_read_input_tokens"])
+            entry.cacheWrite += intVal(usage["cache_creation_input_tokens"])
+            acc[key] = entry
+        }
+    }
+
+    // MARK: Codex
+    //
+    // total_token_usage is CUMULATIVE per session. We walk events in order and
+    // sum per-event deltas (curr − prev, clamped ≥0) whose timestamp is today.
+    // Sessions spanning midnight get the correct today-only increment because
+    // yesterday's events establish the prev baseline.
+
+    private static func parseCodex(
+        _ url: URL, into acc: inout [String: TokenModelUsage], dayStart: Date
+    ) {
+        var label = "Codex"
+        var prevInput: Int?, prevCached = 0, prevOutput = 0, prevReasoning = 0
+        var dInput = 0, dCached = 0, dOutput = 0, dReasoning = 0
+        forEachLine(in: url) { line in
+            guard let obj = jsonObject(line),
+                  obj["type"] as? String == "event_msg",
+                  let payload = obj["payload"] as? [String: Any],
+                  payload["type"] as? String == "token_count" else { return }
+            if let limits = payload["rate_limits"] as? [String: Any],
+               let ln = limits["limit_name"] as? String, !ln.isEmpty {
+                label = ln
+            }
+            guard let info = payload["info"] as? [String: Any],
+                  let totals = info["total_token_usage"] as? [String: Any] else { return }
+            let cInput = intVal(totals["input_tokens"])
+            let cCached = intVal(totals["cached_input_tokens"])
+            let cOutput = intVal(totals["output_tokens"])
+            let cReasoning = intVal(totals["reasoning_output_tokens"])
+            let di = max(0, cInput - (prevInput ?? 0))
+            let dc = max(0, cCached - prevCached)
+            let dou = max(0, cOutput - prevOutput)
+            let dr = max(0, cReasoning - prevReasoning)
+            prevInput = cInput; prevCached = cCached; prevOutput = cOutput; prevReasoning = cReasoning
+            guard let ts = isoDate(obj["timestamp"]), ts >= dayStart else { return }
+            dInput += di; dCached += dc; dOutput += dou; dReasoning += dr
+        }
+        let billableInput = max(0, dInput - dCached)   // input_tokens includes cached
+        let output = dOutput + dReasoning
+        if billableInput + output + dCached == 0 { return }
+        let key = "Codex/" + label
+        var entry = acc[key]
+            ?? TokenModelUsage(model: label, provider: "Codex",
+                               billableInput: 0, output: 0, cacheRead: 0, cacheWrite: 0)
+        entry.billableInput += billableInput
+        entry.output += output
+        entry.cacheRead += dCached
+        acc[key] = entry
+    }
+
+    // MARK: Line iteration (memory-mapped)
+
+    /// Iterate JSONL lines without loading the whole file into the heap. Uses
+    /// .mappedIfSafe so a 200MB+ active session is paged by the OS rather than
+    /// slurped into a Swift String. `body` is non-escaping (called inline), so
+    /// callers may capture inout state.
+    private static func forEachLine(in url: URL, _ body: (String) -> Void) {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else { return }
+        let nl: UInt8 = 0x0A
+        var idx = data.startIndex
+        let end = data.endIndex
+        while idx < end {
+            let lineEnd = data[idx..<end].firstIndex(of: nl) ?? end
+            if lineEnd > idx, let line = String(data: data[idx..<lineEnd], encoding: .utf8) {
+                body(line)
+            }
+            idx = (lineEnd < end) ? data.index(after: lineEnd) : end
+        }
+    }
+
+    // MARK: File discovery
+
+    /// (url, FileMeta) for *.jsonl under root with mtime ≥ cutoff, optionally
+    /// filtered by filename prefix. The mtime filter runs before any read.
+    private static func jsonlFiles(
+        in root: URL, modifiedOnOrAfter cutoff: Date,
+        prefix: String? = nil, fileManager: FileManager
+    ) -> [(URL, FileMeta)] {
+        guard fileManager.fileExists(atPath: root.path),
+              let en = fileManager.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey, .fileSizeKey],
+                options: [.skipsHiddenFiles]
+              ) else { return [] }
+        var out: [(URL, FileMeta)] = []
+        for case let url as URL in en {
+            guard url.pathExtension == "jsonl" else { continue }
+            if let prefix, !url.lastPathComponent.hasPrefix(prefix) { continue }
+            guard let rv = try? url.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey, .fileSizeKey]),
+                  rv.isRegularFile == true,
+                  let mtime = rv.contentModificationDate, mtime >= cutoff else { continue }
+            out.append((url, FileMeta(size: rv.fileSize ?? 0, mtime: mtime)))
+        }
+        return out
+    }
+
+    // MARK: JSON / parsing helpers
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return obj
+    }
+
+    private static func intVal(_ v: Any?) -> Int {
+        switch v {
+        case let n as NSNumber: return n.intValue
+        case let s as String: return Int(s) ?? 0
+        default: return 0
+        }
+    }
+
+    private static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func isoDate(_ v: Any?) -> Date? {
+        guard let s = v as? String else { return nil }
+        return isoFractional.date(from: s) ?? isoPlain.date(from: s)
+    }
+}

--- a/ClaudeIsland/Services/Sync/TerminalWriter.swift
+++ b/ClaudeIsland/Services/Sync/TerminalWriter.swift
@@ -100,11 +100,18 @@ final class TerminalWriter {
         return detectedFallback
     }
 
-    /// Codex's TUI runs in raw mode and wants a real Enter key event to submit.
-    /// Appending `\r` to the text stream only inserts a newline in its composer.
+    /// Codex's TUI runs in raw mode with bracketed paste: a `\r` in the text
+    /// stream is a literal newline in its composer, never a submit. It only
+    /// submits on a real Enter *key* event. That's true whether or not we
+    /// resolved an explicit cmux surface — `cmux send-key` targets the
+    /// workspace's active surface when `--surface` is omitted — so Codex must
+    /// ALWAYS take the send-then-key path. Gating this on `hasSurfaceTarget`
+    /// was the bug: with no surface it fell back to the inline-`\r` path, which
+    /// strands the text in Codex's composer unsent. `hasSurfaceTarget` is kept
+    /// for callers/diagnostics but no longer changes Codex's submit path.
     nonisolated static func cmuxSubmissionPlan(text: String, terminalApp: String?, hasSurfaceTarget: Bool) -> CmuxSubmissionPlan {
         let normalizedApp = terminalApp?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalizedApp == "codex", hasSurfaceTarget {
+        if normalizedApp == "codex" {
             return .sendThenKey(text: text, key: "enter")
         }
 
@@ -844,11 +851,18 @@ final class TerminalWriter {
                 Self.logger.error("cmux send failed for workspace=\(wsId)")
                 return false
             }
-            guard let surfId else {
-                Self.logger.error("cmux submit-key requires a surface for workspace=\(wsId)")
-                return false
-            }
-            guard await cmuxRun(["send-key", "--workspace", wsId, "--surface", surfId, "--", key]) != nil else {
+            // Codex ingests the pasted text on its own raw-mode event loop;
+            // settle briefly so the submit key doesn't land before the composer
+            // holds the text (mirrors the image-path paste settle on line ~751).
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            // `cmux send-key` defaults `--surface` to the workspace's active
+            // surface, so we no longer bail when surfId is nil: the text `send`
+            // above already landed on that active surface. Pass the surface
+            // explicitly when we have one for precision.
+            var keyArgs = ["send-key", "--workspace", wsId]
+            if let surfId { keyArgs += ["--surface", surfId] }
+            keyArgs += ["--", key]
+            guard await cmuxRun(keyArgs) != nil else {
                 Self.logger.error("cmux send-key '\(key)' failed for workspace=\(wsId)")
                 return false
             }

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -88,9 +88,15 @@ struct ClaudeInstancesView: View {
                             .buttonStyle(.plain)
                         }
 
-                        if notchStore.customization.showUsageBar
-                            && notchStore.customization.showClaudeUsageBar {
-                            UsageStatsBar(monitor: rateLimitMonitor, totalMinutes: totalSessionMinutes)
+                        if notchStore.customization.showUsageBar {
+                            // Tokens mode shows ONE unified cross-model bar
+                            // (replacing both plan bars). Otherwise the Claude
+                            // plan-% bar, gated on its sub-toggle.
+                            if notchStore.customization.usageBarDisplayMode == .tokens {
+                                TokenUsageStatsBar(monitor: tokenUsageMonitor)
+                            } else if notchStore.customization.showClaudeUsageBar {
+                                UsageStatsBar(monitor: rateLimitMonitor, totalMinutes: totalSessionMinutes)
+                            }
                         }
                     }
                     .padding(.trailing, 4)
@@ -99,9 +105,11 @@ struct ClaudeInstancesView: View {
                     .transition(.opacity.combined(with: .scale(scale: 0.9)))
                 }
 
-                // Bottom left: Codex usage stats
+                // Bottom left: Codex usage stats (hidden in tokens mode — the
+                // unified token bar already covers Codex)
                 if codexGate.isEnabled && !showBuddyCard && !(sortedInstances.count > 4 && viewModel.isInstancesExpanded)
                     && notchStore.customization.showUsageBar
+                    && notchStore.customization.usageBarDisplayMode != .tokens
                     && notchStore.customization.showCodexUsageBar {
                     VStack(alignment: .leading, spacing: 4) {
                         Spacer()
@@ -125,26 +133,32 @@ struct ClaudeInstancesView: View {
             // hit api.anthropic.com every 5 minutes. See issue #50.
             // Also gate on the Claude sub-toggle so users who only want Codex
             // shown don't pay the Claude API poll cost.
-            .onAppear {
-                if notchStore.customization.showUsageBar
-                    && notchStore.customization.showClaudeUsageBar {
-                    rateLimitMonitor.start()
-                }
-            }
-            .onChange(of: notchStore.customization.showUsageBar) { _, newValue in
-                if newValue && notchStore.customization.showClaudeUsageBar {
-                    rateLimitMonitor.start()
-                } else {
-                    rateLimitMonitor.stop()
-                }
-            }
-            .onChange(of: notchStore.customization.showClaudeUsageBar) { _, newValue in
-                if newValue && notchStore.customization.showUsageBar {
-                    rateLimitMonitor.start()
-                } else {
-                    rateLimitMonitor.stop()
-                }
-            }
+            .onAppear { syncUsageMonitors() }
+            .onChange(of: notchStore.customization.showUsageBar) { _, _ in syncUsageMonitors() }
+            .onChange(of: notchStore.customization.showClaudeUsageBar) { _, _ in syncUsageMonitors() }
+            .onChange(of: notchStore.customization.usageBarDisplayMode) { _, _ in syncUsageMonitors() }
+        }
+    }
+
+    /// Single source of truth for which usage monitors should be running.
+    /// Tokens mode shows the unified local-transcript meter and HIDES the plan
+    /// bars, so the Anthropic usage-API poll (rateLimitMonitor) must be stopped
+    /// in that mode — otherwise it keeps hitting api.anthropic.com every 5 min
+    /// for a bar that isn't visible (the issue #50 regression). Leaving tokens
+    /// mode restarts the plan monitor if its bar would show.
+    @MainActor
+    private func syncUsageMonitors() {
+        let c = notchStore.customization
+        let tokensMode = c.showUsageBar && c.usageBarDisplayMode == .tokens
+        if tokensMode {
+            tokenUsageMonitor.start()
+        } else {
+            tokenUsageMonitor.stop()
+        }
+        if c.showUsageBar && !tokensMode && c.showClaudeUsageBar {
+            rateLimitMonitor.start()
+        } else {
+            rateLimitMonitor.stop()
         }
     }
 
@@ -301,13 +315,18 @@ struct ClaudeInstancesView: View {
 
                 // Usage stats if available (honors showUsageBar + sub-toggles)
                 if notchStore.customization.showUsageBar {
-                    if notchStore.customization.showClaudeUsageBar {
-                        UsageStatsBar(monitor: rateLimitMonitor, totalMinutes: 0)
+                    if notchStore.customization.usageBarDisplayMode == .tokens {
+                        TokenUsageStatsBar(monitor: tokenUsageMonitor)
                             .padding(.top, 4)
-                    }
-                    if codexGate.isEnabled && notchStore.customization.showCodexUsageBar {
-                        CodexUsageStatsBar(monitor: codexUsageMonitor)
-                            .padding(.top, 4)
+                    } else {
+                        if notchStore.customization.showClaudeUsageBar {
+                            UsageStatsBar(monitor: rateLimitMonitor, totalMinutes: 0)
+                                .padding(.top, 4)
+                        }
+                        if codexGate.isEnabled && notchStore.customization.showCodexUsageBar {
+                            CodexUsageStatsBar(monitor: codexUsageMonitor)
+                                .padding(.top, 4)
+                        }
                     }
                 }
             }
@@ -345,6 +364,7 @@ struct ClaudeInstancesView: View {
 
     @StateObject private var rateLimitMonitor = RateLimitMonitor.shared
     @StateObject private var codexUsageMonitor = CodexUsageMonitor.shared
+    @StateObject private var tokenUsageMonitor = TokenUsageMonitor.shared
     @ObservedObject private var codexGate = CodexFeatureGate.shared
 
     // MARK: - Instances List
@@ -1536,7 +1556,10 @@ struct UsageStatsBar: View {
             if let info = monitor.rateLimitInfo {
                 Group {
                     switch effectiveMode {
-                    case .auto, .compact: compactBody(info: info)
+                    // .tokens never reaches here (the unified TokenUsageStatsBar
+                    // replaces this bar in tokens mode), but the switch must be
+                    // exhaustive — fall back to compact defensively.
+                    case .auto, .compact, .tokens: compactBody(info: info)
                     case .alert: alertBody(info: info)
                     case .time: timeBody(info: info)
                     }
@@ -1853,7 +1876,8 @@ struct CodexUsageStatsBar: View {
 
                     Group {
                         switch effectiveMode {
-                        case .auto, .compact:
+                        // .tokens handled by the unified bar; fall back to compact.
+                        case .auto, .compact, .tokens:
                             HStack(spacing: 6) {
                                 ForEach(snapshot.windows) { window in
                                     usageGaugeCompact(
@@ -2094,5 +2118,166 @@ struct CodexUsageStatsBar: View {
         let remaining = resetAt.timeIntervalSinceNow
         if remaining <= 0 { return "Codex \(label): \(pct)% (reset)" }
         return "Codex \(label): \(pct)% (resets in \(formatResetShort(remaining)))"
+    }
+}
+
+// MARK: - Token Usage Stats Bar
+//
+// Unified, cross-model token meter (UsageBarDisplayMode.tokens). Reads today's
+// actual token consumption from the local CLI transcripts via TokenUsageMonitor
+// and replaces the per-provider plan-% bars when selected. Headline number is
+// "billable" (input+output); cache tokens are shown muted because they are
+// nearly free and would otherwise dwarf the real number (cache can be 100x+).
+
+struct TokenUsageStatsBar: View {
+    @ObservedObject var monitor: TokenUsageMonitor
+    @ObservedObject private var notchStore: NotchCustomizationStore = .shared
+    private var theme: ThemeResolver { ThemeResolver(theme: notchStore.customization.theme) }
+
+    @State private var appear = false
+    @State private var pulsePhase = false
+    @State private var justRefreshed = false
+
+    private func fmt(_ n: Int) -> String {
+        if n >= 1_000_000 {
+            let m = Double(n) / 1_000_000
+            return String(format: m >= 100 ? "%.0fM" : "%.1fM", m)
+        }
+        if n >= 1_000 {
+            let k = Double(n) / 1_000
+            return String(format: k >= 100 ? "%.0fK" : "%.1fK", k)
+        }
+        return "\(n)"
+    }
+
+    /// Compact, friendly model label. "claude-opus-4-8" → "Opus 4.8".
+    /// Only trailing NUMERIC segments form the version, so a degenerate name
+    /// like bare "opus" yields "Opus" (not "Opus opus").
+    private func shortLabel(_ u: TokenModelUsage) -> String {
+        let m = u.model.lowercased()
+        func ver() -> String {
+            // take trailing parts that look like version numbers (e.g. 4, 8)
+            let digits = m.split(separator: "-").filter { $0.allSatisfy { $0.isNumber } }
+            return digits.suffix(2).joined(separator: ".")
+        }
+        func labeled(_ family: String) -> String {
+            let v = ver()
+            return v.isEmpty ? family : "\(family) \(v)"
+        }
+        if m.contains("opus") { return labeled("Opus") }
+        if m.contains("sonnet") { return labeled("Sonnet") }
+        if m.contains("haiku") { return labeled("Haiku") }
+        if u.provider == "Codex" { return "Codex" }
+        return u.model
+    }
+
+    private var codexBlue: Color { Color(red: 0.56, green: 0.79, blue: 0.98) }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let snap = monitor.snapshot, !snap.isEmpty {
+                // Headline: today's total billable.
+                HStack(spacing: 4) {
+                    Text(L10n.usageBarTokensToday)
+                        .notchFont(7, weight: .semibold)
+                        .foregroundColor(theme.mutedText)
+                        .lineLimit(1)
+                    Text(fmt(snap.totalBillable))
+                        .notchFont(13, weight: .bold, design: .monospaced)
+                        .foregroundColor(theme.doneColor)
+                        .lineLimit(1)
+                }
+                Rectangle()
+                    .fill(theme.usageBorder.opacity(0.5))
+                    .frame(width: 1, height: 14)
+                // Per-model billable, inline (no wrap). Same value size as the
+                // headline so the numbers read consistently across the row.
+                ForEach(snap.models.prefix(3)) { u in
+                    HStack(spacing: 4) {
+                        Text(shortLabel(u))
+                            .notchFont(11, weight: .medium)
+                            .foregroundColor(u.provider == "Codex" ? codexBlue : theme.usageText)
+                            .lineLimit(1)
+                        Text(fmt(u.billable))
+                            .notchFont(13, weight: .semibold, design: .monospaced)
+                            .foregroundColor(theme.usageText)
+                            .lineLimit(1)
+                    }
+                }
+                if snap.models.count > 3 {
+                    Text(L10n.usageBarTokensMore(snap.models.count - 3))
+                        .notchFont(7, weight: .regular)
+                        .foregroundColor(theme.mutedText)
+                        .opacity(0.5)
+                        .lineLimit(1)
+                }
+                // Cache total, de-emphasized, at the end.
+                Text(L10n.usageBarTokensCached(fmt(snap.totalCache)))
+                    .notchFont(7, weight: .regular)
+                    .foregroundColor(theme.usageText)
+                    .opacity(0.45)
+                    .lineLimit(1)
+                refreshIndicator
+            } else {
+                Text(L10n.usageBarTokensEmpty)
+                    .notchFont(8, weight: .regular)
+                    .foregroundColor(theme.mutedText)
+                    .opacity(0.6)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)   // single line, no wrap/compress
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(theme.overlay.opacity(0.16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(theme.usageBorder.opacity(0.7), lineWidth: 0.5)
+                )
+        )
+        .opacity(appear ? 1 : 0)
+        .offset(y: appear ? 0 : 5)
+        .contentShape(Rectangle())
+        .onTapGesture { Task { await refreshWithFeedback() } }
+        .help(monitor.isLoading ? L10n.usageBarRefreshingHint
+              : (justRefreshed ? L10n.usageBarJustRefreshed : L10n.usageBarTapToRefresh))
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true)) {
+                pulsePhase = true
+            }
+            withAnimation(.easeOut(duration: 0.4).delay(0.3)) {
+                appear = true
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var refreshIndicator: some View {
+        if monitor.isLoading {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .notchFont(8, weight: .regular)
+                .foregroundColor(theme.mutedText)
+                .rotationEffect(.degrees(pulsePhase ? 360 : 0))
+                .animation(.linear(duration: 1).repeatForever(autoreverses: false), value: pulsePhase)
+                .padding(.leading, 6)
+        } else if justRefreshed {
+            HStack(spacing: 2) {
+                Image(systemName: "checkmark.circle.fill")
+                    .notchFont(8, weight: .regular)
+                Text(L10n.usageBarJustNow)
+                    .notchFont(8, weight: .semibold)
+            }
+            .foregroundColor(theme.doneColor)
+            .padding(.leading, 6)
+            .transition(.opacity.combined(with: .scale(scale: 0.85)))
+        }
+    }
+
+    private func refreshWithFeedback() async {
+        await monitor.refresh()
+        withAnimation(.easeOut(duration: 0.25)) { justRefreshed = true }
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        withAnimation(.easeIn(duration: 0.4)) { justRefreshed = false }
     }
 }

--- a/ClaudeIsland/UI/Views/NotchCustomizationSettingsView.swift
+++ b/ClaudeIsland/UI/Views/NotchCustomizationSettingsView.swift
@@ -284,6 +284,7 @@ struct NotchCustomizationSettingsView: View {
         case .alert: return L10n.usageBarModeAlert
         case .compact: return L10n.usageBarModeCompact
         case .time: return L10n.usageBarModeTime
+        case .tokens: return L10n.usageBarModeTokens
         }
     }
 
@@ -293,6 +294,7 @@ struct NotchCustomizationSettingsView: View {
         case .alert: return L10n.usageBarModeAlertDescription
         case .compact: return L10n.usageBarModeCompactDescription
         case .time: return L10n.usageBarModeTimeDescription
+        case .tokens: return L10n.usageBarModeTokensDescription
         }
     }
 

--- a/ClaudeIslandTests/TerminalWriterRoutingTests.swift
+++ b/ClaudeIslandTests/TerminalWriterRoutingTests.swift
@@ -58,13 +58,30 @@ final class TerminalWriterRoutingTests: XCTestCase {
         XCTAssertEqual(plan, .appendReturn("OK\r"))
     }
 
-    func test_codexFallsBackToInlineReturnWithoutSurface() {
+    /// Regression: Codex's raw-mode TUI only submits on a real Enter KEY event;
+    /// an inline `\r` is a literal newline in its composer and strands the text
+    /// unsent. So Codex must use send-then-key even when no surface was
+    /// resolved (`cmux send-key` defaults to the workspace's active surface).
+    /// Previously this returned `.appendReturn("OK\r")` — that was the bug.
+    func test_codexUsesSeparateEnterKeyEvenWithoutSurface() {
         let plan = TerminalWriter.cmuxSubmissionPlan(
             text: "OK",
             terminalApp: "Codex",
             hasSurfaceTarget: false
         )
 
-        XCTAssertEqual(plan, .appendReturn("OK\r"))
+        XCTAssertEqual(plan, .sendThenKey(text: "OK", key: "enter"))
+    }
+
+    /// terminalApp matching is case- and whitespace-insensitive, so a "codex"
+    /// hint from any source still gets the key-event submit path.
+    func test_codexMatchIsCaseAndWhitespaceInsensitive() {
+        let plan = TerminalWriter.cmuxSubmissionPlan(
+            text: "hi",
+            terminalApp: "  codex ",
+            hasSurfaceTarget: false
+        )
+
+        XCTAssertEqual(plan, .sendThenKey(text: "hi", key: "enter"))
     }
 }


### PR DESCRIPTION
## What

Three things batched into one release (v3.0.4):

### 1. Cross-model token-consumption meter (new "Tokens" usage-bar mode)
- New `TokenUsage.swift`: reads **today's real token consumption** from the local CLI transcripts (`~/.claude/projects` + `~/.codex/sessions`), aggregated across all models, deduped by message id, parsed **off the main thread** on a 60s poll with stat-based change detection (idle = no content read).
- Works even when the plan % reads **0%** (Spark / proxied / `ANTHROPIC_BASE_URL` / relayed setups) — it counts from the local transcript, not the rate-limit API.
- New `UsageBarDisplayMode.tokens` + a unified `TokenUsageStatsBar` that replaces the per-provider plan bars when selected. The monitor only runs while tokens mode is active (`start()`/`stop()` lifecycle).
- Settings → 灵动岛 → 用量条 exposes the new mode with label + description.

### 2. New "Catppuccin" notch theme + color refresh
- Adds the `catppuccin` built-in theme, and a contrast/consistency color pass over the 7 existing built-in themes.

### 3. Codex submit fix
- `cmuxSubmissionPlan` no longer gates the Enter-**key** path on `hasSurfaceTarget`. Codex's raw-mode TUI only submits on a real Enter key event; an inline `\r` with no resolved surface stranded the text unsent. It now always send-then-keys (+150ms settle). Routing tests updated.

## Test
- `xcodebuild build -scheme ClaudeIsland -configuration Debug` on the merged branch (token meter + the already-shipped v3.0.3 changes) → **BUILD SUCCEEDED**.
- ⚠️ Not runtime-UI-verified in this session; the token meter has been dogfooded locally by the author prior to this. Merges cleanly with v3.0.3 (no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)