### PR TITLE
Account-only identity + monitoring fixes (account↔computer pairing)

### DIFF
--- a/ClaudeIsland/Core/Localization.swift
+++ b/ClaudeIsland/Core/Localization.swift
@@ -292,6 +292,9 @@ enum L10n {
     static var pairPanelStoredLocally: String { tr("The server URL is stored locally and never leaves your Mac.", "服务器地址仅保存在本机，不会外发。") }
     static var pairPanelStepScanTitle: String { tr("Step 2 · Scan with Code Light", "第 2 步 · 用 Code Light 扫码") }
     static var pairPanelStepScanBody: String { tr("Open Code Light on iPhone and scan this QR, or enter the short code manually.", "在 iPhone 打开 Code Light，扫描下方二维码，或手动输入配对码。") }
+    /// #118: shown when the QR carries both monitoring + workspace (one scan does both).
+    static var pairPanelStepScanBodyBoth: String { tr("One scan pairs monitoring AND this workspace.", "一次扫码即可同时配对监控与本工作区。") }
+    static var pairScanCaptionBoth: String { tr("Monitoring + workspace · one scan", "监控 + 工作区 · 一次扫码") }
     static var pairPanelShortCodeLabel: String { tr("Pairing Code", "配对码") }
     static var pairPanelGeneratingCode: String { tr("Generating pairing code…", "生成配对码中…") }
     static var pairPanelLinkedDevices: String { tr("Linked Devices", "已连接设备") }
@@ -629,6 +632,7 @@ enum L10n {
     ) }
 
     // Section labels
+    static var agentSectionWorkspace: String    { tr("This workspace",         "本工作区") }
     static var agentSectionLifecycle: String    { tr("Lifecycle",              "生命周期") }
     static var agentSectionControls: String     { tr("Controls",               "控制") }
     static var agentSectionLogs: String         { tr("Logs",                   "日志") }
@@ -688,6 +692,8 @@ enum L10n {
     // Diagnostic / action messages
     static var agentDiagInstalling: String          { tr("Installing…",              "安装中…") }
     static var agentDiagBundleNotFound: String      { tr("mio-agent was not found in the app bundle.", "在应用包中未找到 mio-agent。") }
+    static var agentDiagUsingNpx: String            { tr("Using npx-cached daemon (no binary download needed)…", "使用 npx 缓存的守护进程（无需下载二进制）…") }
+    static var agentDiagSigning: String             { tr("Signing binary…",         "正在签名二进制…") }
     static var agentDiagStarting: String            { tr("Starting…",               "启动中…") }
     static var agentDiagStartSent: String           { tr("Start command sent — verify status above.", "启动命令已发送 — 请查看上方状态。") }
     static var agentDiagStopping: String            { tr("Stopping…",               "停止中…") }
@@ -715,6 +721,29 @@ enum L10n {
     static func agentLastChecked(_ time: String) -> String {
         tr("Last checked \(time)", "最后检查 \(time)")
     }
+
+    // MARK: - Workspace status panel (#117)
+
+    static var wsRowWorkspace: String   { tr("Workspace",   "工作区") }
+    static var wsRowDaemon: String      { tr("Daemon",      "守护进程") }
+    static var wsRowMonitoring: String  { tr("Monitoring",  "会话监控") }
+    static var wsRowDistribution: String { tr("Launch path", "启动方式") }
+
+    static var wsDaemonOnline: String   { tr("Online",      "在线") }
+    static var wsDaemonOffline: String  { tr("Offline",     "离线") }
+    static var wsMonitoringOn: String   { tr("Connected",   "已连接") }
+    static var wsMonitoringOff: String  { tr("Not connected", "未连接") }
+    static var wsMonitoringConnecting: String { tr("Connecting…", "连接中…") }
+
+    static var wsDistNpx: String        { tr("npx-cached",  "npx 缓存") }
+    static var wsDistBinary: String     { tr("Installed binary", "已安装二进制") }
+    static var wsDistNone: String       { tr("Not available", "不可用") }
+
+    static var wsWorkspaceUnconfigured: String { tr("Not enrolled", "未注册") }
+    static var wsDaemonHint: String { tr(
+        "Online means mio-agent is running and answering its local health check. The server marks this machine online via a 45s heartbeat.",
+        "「在线」表示 mio-agent 正在运行并通过本地健康检查。服务器通过 45 秒心跳判定此机器在线。"
+    ) }
 
     // MARK: - In-app enrollment (MioAgentEnroller / R2.1)
 
@@ -757,6 +786,10 @@ enum L10n {
     static var agentEnrollErrNoBinary: String { tr(
         "mio-agent is not installed. Install it first, then enroll.",
         "mio-agent 未安装。请先安装再注册。"
+    ) }
+    static var agentEnrollErrNoLauncher: String { tr(
+        "Cannot launch mio-agent: neither npx nor an installed binary was found. Install Node.js (npx) or use Install in Controls.",
+        "无法启动 mio-agent：既未找到 npx，也没有已安装的二进制。请安装 Node.js（npx）或在控制区点击安装。"
     ) }
     static func agentEnrollErrLaunch(_ msg: String) -> String {
         tr("Could not launch mio-agent login: \(msg)", "无法启动 mio-agent login：\(msg)")

--- a/ClaudeIsland/Core/Localization.swift
+++ b/ClaudeIsland/Core/Localization.swift
@@ -559,4 +559,167 @@ enum L10n {
         default: return ThemeRegistry.shared.displayName(for: id)
         }
     }
+
+    // MARK: - Mio Agent Settings (AgentSettingsTab)
+
+    // Phase primary labels
+    static var agentPhaseLabelChecking: String       { tr("Checking…",                      "检查中…") }
+    static var agentPhaseLabelNotInstalled: String   { tr("Not installed",                  "未安装") }
+    static var agentPhaseLabelNotConfigured: String  { tr("Setup required",                 "需要配置") }
+    static var agentPhaseLabelInstalledUnloaded: String { tr("Installed · stopped",         "已安装 · 未启动") }
+    static var agentPhaseLabelLoadedStopped: String  { tr("Loaded · not running",           "已加载 · 未运行") }
+    static var agentPhaseLabelStarting: String       { tr("Starting…",                      "启动中…") }
+    static var agentPhaseLabelRunningHealthy: String { tr("Running",                        "运行中") }
+    static var agentPhaseLabelRunningUnhealthy: String { tr("Running · health check failed","运行中 · 健康检查失败") }
+    static var agentPhaseLabelDraining: String       { tr("Stopping safely…",              "安全停止中…") }
+    static var agentPhaseLabelStopping: String       { tr("Stopping…",                     "停止中…") }
+    static var agentPhaseLabelError: String          { tr("Action failed",                  "操作失败") }
+    static var agentPhaseLabelUnknown: String        { tr("Status unknown",                 "状态未知") }
+
+    // Phase description text
+    static var agentPhaseDescChecking: String { tr(
+        "Probing agent status…",
+        "正在探测 agent 状态…"
+    ) }
+    static var agentPhaseDescNotInstalled: String { tr(
+        "Install the bundled mio-agent before starting local action execution.",
+        "请先安装内置的 mio-agent 以启动本地动作执行。"
+    ) }
+    static var agentPhaseDescNotConfigured: String { tr(
+        "Agent is installed but not configured. Run mio-agent login in Terminal to set up before starting.",
+        "Agent 已安装但未配置。请在终端运行 mio-agent login 完成配置后再启动。"
+    ) }
+    static var agentPhaseDescInstalledUnloaded: String { tr(
+        "The LaunchAgent is not running. Start it to prepare local action execution.",
+        "LaunchAgent 未运行。启动它以准备本地动作执行。"
+    ) }
+    static var agentPhaseDescLoadedStopped: String { tr(
+        "The job is loaded but the process is not running. Start will kickstart the job.",
+        "任务已加载但进程未运行。点击启动将重新拉起进程。"
+    ) }
+    static var agentPhaseDescStarting: String { tr(
+        "Wait; controls are disabled while the agent starts.",
+        "请等待；agent 启动期间操作禁用。"
+    ) }
+    static var agentPhaseDescRunningHealthy: String { tr(
+        "mio-agent is available on this Mac.",
+        "mio-agent 已在此 Mac 上运行。"
+    ) }
+    static var agentPhaseDescRunningUnhealthy: String { tr(
+        "The process exists, but the local health endpoint did not respond.",
+        "进程存在，但本地健康检查端点未响应。"
+    ) }
+    static var agentPhaseDescDraining: String { tr(
+        "Waiting for in-flight actions to reach a safe stopping point.",
+        "等待进行中的动作到达安全停止点。"
+    ) }
+    static var agentPhaseDescStopping: String { tr(
+        "The agent will be unloaded from launchd. Drain-safe stop is coming in Phase 2.",
+        "Agent 将从 launchd 卸载。Phase 2 将支持安全排空停止。"
+    ) }
+    static var agentPhaseDescUnknown: String { tr(
+        "Could not determine agent status. Refresh to try again.",
+        "无法确定 agent 状态。刷新以重试。"
+    ) }
+
+    // Tab description
+    static var agentTabDescription: String { tr(
+        "Mio Agent is a background daemon that communicates with AI runtimes, fires actions, and reports results to MioServer.",
+        "Mio Agent 是一个后台守护进程，负责与 AI 运行时通信、触发动作并将结果上报至 MioServer。"
+    ) }
+
+    // Section labels
+    static var agentSectionLifecycle: String    { tr("Lifecycle",              "生命周期") }
+    static var agentSectionControls: String     { tr("Controls",               "控制") }
+    static var agentSectionLogs: String         { tr("Logs",                   "日志") }
+    static var agentSectionCapabilities: String { tr("Capabilities (coming soon)", "能力（即将推出）") }
+
+    // Lifecycle row labels
+    static var agentRowBinary: String      { tr("Binary",      "可执行文件") }
+    static var agentRowConfig: String      { tr("Config",      "配置文件") }
+    static var agentRowLaunchAgent: String { tr("LaunchAgent", "LaunchAgent") }
+    static var agentRowProcess: String     { tr("Process",     "进程") }
+    static var agentRowHealth: String      { tr("Health",      "健康检查") }
+    static var agentRowSocket: String      { tr("Socket",      "套接字") }
+
+    // Lifecycle state pills
+    static var agentStateInstalled: String     { tr("Installed",   "已安装") }
+    static var agentStateMissing: String       { tr("Missing",     "缺失") }
+    static var agentStateConfigPresent: String { tr("Present",     "存在") }
+    static var agentStateConfigMissing: String { tr("Missing — run mio-agent login", "缺失 — 请运行 mio-agent login") }
+    static var agentStateLoaded: String        { tr("Loaded",      "已加载") }
+    static var agentStateUnloaded: String      { tr("Unloaded",    "未加载") }
+    static var agentStateRunning: String       { tr("Running",     "运行中") }
+    static var agentStateStopped: String       { tr("Stopped",     "已停止") }
+    static var agentStateOK: String            { tr("OK",          "正常") }
+    static var agentStateFailed: String        { tr("Failed",      "失败") }
+    static var agentStateUnavailable: String   { tr("Unavailable", "不可用") }
+    static var agentStateSocketPending: String { tr("Pending Phase 2", "Phase 2 开放") }
+    static var agentStateUnknown: String       { tr("Unknown",     "未知") }
+
+    // Button labels
+    static var agentButtonInstall: String  { tr("Install",           "安装") }
+    static var agentButtonStart: String    { tr("Start",             "启动") }
+    static var agentButtonStop: String     { tr("Stop",              "停止") }
+    static var agentButtonOpenLog: String  { tr("Open log file",     "打开日志文件") }
+    static var agentButtonCopyLog: String  { tr("Copy last 100 lines", "复制最后 100 行") }
+
+    // Setup required hint
+    static var agentSetupHintCommand: String { tr(
+        "Run this command in Terminal, then enter your server URL (e.g. https://mio.wdao.chat) when prompted:",
+        "在终端运行此命令，按提示输入服务器 URL（如 https://mio.wdao.chat）："
+    ) }
+    static var agentSetupHintCopy: String { tr("Copy command", "复制命令") }
+
+    // Logs card
+    static var agentLogsHint: String { tr(
+        "Use logs for install/start/stop diagnostics. Sensitive values are not expected here.",
+        "使用日志诊断安装/启动/停止问题。此处不应包含敏感信息。"
+    ) }
+    static var agentLogsEmpty: String { tr(
+        "No agent log yet — ~/.mio/agent.log will be created once the agent starts successfully.",
+        "暂无 agent 日志 — agent 成功启动后将创建 ~/.mio/agent.log。"
+    ) }
+
+    // Capabilities card
+    static var agentCapSoon: String               { tr("Soon",                             "即将推出") }
+    static var agentCapActionExecution: String    { tr("Action execution",                 "动作执行") }
+    static var agentCapActionDesc: String         { tr("Requires Phase 2 IPC — runtime adapter integration", "需要 Phase 2 IPC — 运行时适配器集成") }
+    static var agentCapWorkroom: String           { tr("Workroom binding",                 "工作室绑定") }
+    static var agentCapWorkroomDesc: String       { tr("Requires MioServer human-auth cursor", "需要 MioServer 人工鉴权游标") }
+    static var agentCapLogStreaming: String        { tr("Log streaming",                   "日志流") }
+    static var agentCapLogStreamingDesc: String   { tr("Requires IPC socket integration", "需要 IPC socket 集成") }
+    static var agentCapAutoUpgrade: String        { tr("Auto-upgrade (SMAppService)",      "自动升级（SMAppService）") }
+    static var agentCapAutoUpgradeDesc: String    { tr("Requires upgrade.ts re-register mechanism", "需要 upgrade.ts 重注册机制") }
+
+    // Diagnostic / action messages
+    static var agentDiagInstalling: String          { tr("Installing…",              "安装中…") }
+    static var agentDiagBundleNotFound: String      { tr("mio-agent was not found in the app bundle.", "在应用包中未找到 mio-agent。") }
+    static var agentDiagStarting: String            { tr("Starting…",               "启动中…") }
+    static var agentDiagStartSent: String           { tr("Start command sent — verify status above.", "启动命令已发送 — 请查看上方状态。") }
+    static var agentDiagStopping: String            { tr("Stopping…",               "停止中…") }
+    static var agentDiagProcessStillRunning: String { tr("Process still running after stop request.", "停止请求后进程仍在运行。") }
+    static func agentDiagBootstrapFailed(_ exit: Int32) -> String {
+        tr("Could not register LaunchAgent (launchctl exit \(exit)).",
+           "LaunchAgent 注册失败（launchctl 退出码 \(exit)）。")
+    }
+    static func agentDiagInstallFailed(_ msg: String) -> String {
+        tr("Install failed: \(msg)", "安装失败：\(msg)")
+    }
+    static func agentDiagStartFailed(bootstrapExit: Int32, kickExit: Int32) -> String {
+        tr("Start failed (bootstrap exit \(bootstrapExit), kickstart exit \(kickExit)).",
+           "启动失败（bootstrap 退出码 \(bootstrapExit)，kickstart 退出码 \(kickExit)）。")
+    }
+    static func agentDiagStopFailed(_ exit: Int32) -> String {
+        tr("Could not unload LaunchAgent (launchctl exit \(exit)).",
+           "无法卸载 LaunchAgent（launchctl 退出码 \(exit)）。")
+    }
+    static var agentDiagErrorFallback: String { tr("An error occurred.", "发生了错误。") }
+    static var agentDiagNoLog: String { tr(
+        "No agent log. The agent has not started successfully yet.",
+        "暂无 agent 日志。Agent 尚未成功启动。"
+    ) }
+    static func agentLastChecked(_ time: String) -> String {
+        tr("Last checked \(time)", "最后检查 \(time)")
+    }
 }

--- a/ClaudeIsland/Core/Localization.swift
+++ b/ClaudeIsland/Core/Localization.swift
@@ -586,8 +586,8 @@ enum L10n {
         "请先安装内置的 mio-agent 以启动本地动作执行。"
     ) }
     static var agentPhaseDescNotConfigured: String { tr(
-        "Agent is installed but not configured. Run mio-agent login in Terminal to set up before starting.",
-        "Agent 已安装但未配置。请在终端运行 mio-agent login 完成配置后再启动。"
+        "Agent is installed but not enrolled. Use the Workspace enrollment card below to configure it in-app — no Terminal required.",
+        "Agent 已安装但未注册。请使用下方的工作区配置卡在应用内完成配置 —— 无需打开终端。"
     ) }
     static var agentPhaseDescInstalledUnloaded: String { tr(
         "The LaunchAgent is not running. Start it to prepare local action execution.",
@@ -646,7 +646,7 @@ enum L10n {
     static var agentStateInstalled: String     { tr("Installed",   "已安装") }
     static var agentStateMissing: String       { tr("Missing",     "缺失") }
     static var agentStateConfigPresent: String { tr("Present",     "存在") }
-    static var agentStateConfigMissing: String { tr("Missing — run mio-agent login", "缺失 — 请运行 mio-agent login") }
+    static var agentStateConfigMissing: String { tr("Missing — enroll below", "缺失 — 在下方注册") }
     static var agentStateLoaded: String        { tr("Loaded",      "已加载") }
     static var agentStateUnloaded: String      { tr("Unloaded",    "未加载") }
     static var agentStateRunning: String       { tr("Running",     "运行中") }
@@ -663,13 +663,6 @@ enum L10n {
     static var agentButtonStop: String     { tr("Stop",              "停止") }
     static var agentButtonOpenLog: String  { tr("Open log file",     "打开日志文件") }
     static var agentButtonCopyLog: String  { tr("Copy last 100 lines", "复制最后 100 行") }
-
-    // Setup required hint
-    static var agentSetupHintCommand: String { tr(
-        "Run this command in Terminal, then enter your server URL (e.g. https://mio.wdao.chat) when prompted:",
-        "在终端运行此命令，按提示输入服务器 URL（如 https://mio.wdao.chat）："
-    ) }
-    static var agentSetupHintCopy: String { tr("Copy command", "复制命令") }
 
     // Logs card
     static var agentLogsHint: String { tr(
@@ -721,5 +714,91 @@ enum L10n {
     ) }
     static func agentLastChecked(_ time: String) -> String {
         tr("Last checked \(time)", "最后检查 \(time)")
+    }
+
+    // MARK: - In-app enrollment (MioAgentEnroller / R2.1)
+
+    // Enroll card — section + copy
+    static var agentEnrollSection: String { tr("Workspace enrollment", "工作区配置") }
+    static var agentEnrollNeededTitle: String { tr("Configure this workspace", "配置此工作区") }
+    static var agentEnrollNeededBody: String { tr(
+        "Enroll this Mac as a workspace daemon. MioIsland runs mio-agent login for you and the binary writes its own Keychain + ~/.mio/agent.json — no Terminal required.",
+        "将此 Mac 注册为工作区守护进程。MioIsland 将为你运行 mio-agent login，二进制会自行写入 Keychain 与 ~/.mio/agent.json —— 无需打开终端。"
+    ) }
+    static var agentEnrollServerLabel: String { tr("Server URL", "服务器 URL") }
+    static var agentEnrollServerPlaceholder: String { tr("https://mio.wdao.chat", "https://mio.wdao.chat") }
+    static var agentEnrollDeviceLabel: String { tr("Device name", "设备名称") }
+    static var agentEnrollButtonStart: String { tr("Enroll workspace", "注册工作区") }
+    static var agentEnrollButtonCancel: String { tr("Cancel", "取消") }
+    static var agentEnrollButtonReEnroll: String { tr("Re-enroll", "重新注册") }
+    static var agentEnrollButtonDone: String { tr("Done", "完成") }
+    static var agentEnrollButtonRetry: String { tr("Retry", "重试") }
+
+    // Enroll phase status copy
+    static var agentEnrollLaunching: String { tr(
+        "Starting mio-agent login…",
+        "正在启动 mio-agent login…"
+    ) }
+    static var agentEnrollAwaiting: String { tr(
+        "Scan the Pair-iPhone QR (it now also carries this enrollment) and approve on your phone. Waiting for approval…",
+        "扫描配对 iPhone 二维码（现已同时携带此注册请求）并在手机上确认。等待批准中…"
+    ) }
+    static var agentEnrollSucceeded: String { tr(
+        "Enrolled. mio-agent wrote its Keychain token and ~/.mio/agent.json. You can start the daemon below.",
+        "已注册。mio-agent 已写入 Keychain 令牌与 ~/.mio/agent.json。可在下方启动守护进程。"
+    ) }
+    static var agentEnrollCopyDeeplink: String { tr("Copy enrollment link", "复制注册链接") }
+    static var agentEnrollAlreadyConfigured: String { tr(
+        "This workspace is enrolled. Re-enroll to bind it to a different account or workspace.",
+        "此工作区已注册。如需绑定其他账户或工作区，可重新注册。"
+    ) }
+
+    // Enroll errors
+    static var agentEnrollErrNoBinary: String { tr(
+        "mio-agent is not installed. Install it first, then enroll.",
+        "mio-agent 未安装。请先安装再注册。"
+    ) }
+    static func agentEnrollErrLaunch(_ msg: String) -> String {
+        tr("Could not launch mio-agent login: \(msg)", "无法启动 mio-agent login：\(msg)")
+    }
+    static func agentEnrollErrExit(_ code: Int32) -> String {
+        tr("Enrollment failed (mio-agent login exit \(code)).", "注册失败（mio-agent login 退出码 \(code)）。")
+    }
+
+    // Autonomous agent block editor
+    static var agentAutoSection: String { tr("Autonomous agent", "自治 agent") }
+    static var agentAutoEnabledLabel: String { tr("Run autonomous agent loop", "运行自治 agent 循环") }
+    static var agentAutoEnabledSublabel: String { tr(
+        "Default-off. When on, the daemon subscribes to a channel and replies autonomously.",
+        "默认关闭。开启后，守护进程将订阅一个频道并自治回复。"
+    ) }
+    static var agentAutoWorkroomLabel: String { tr("Workroom ID", "工作室 ID") }
+    static var agentAutoChannelLabel: String { tr("Channel ID", "频道 ID") }
+    static var agentAutoHandleLabel: String { tr("Handle", "触发标识") }
+    static var agentAutoQuietLabel: String { tr("Quiet seconds", "静默秒数") }
+    static var agentAutoMaxRepliesLabel: String { tr("Max replies / window", "每窗口最大回复数") }
+    static var agentAutoWindowLabel: String { tr("Window seconds", "窗口秒数") }
+    static var agentAutoSave: String { tr("Save agent config", "保存 agent 配置") }
+    static var agentAutoClear: String { tr("Remove block", "移除配置块") }
+    static var agentAutoSaved: String { tr("Saved to ~/.mio/agent.json.", "已保存至 ~/.mio/agent.json。") }
+    static var agentAutoNeedsConfig: String { tr(
+        "Enroll this workspace first — the autonomous block lives in ~/.mio/agent.json.",
+        "请先注册此工作区 —— 自治配置块位于 ~/.mio/agent.json。"
+    ) }
+    static var agentAutoRequiresWorkroom: String { tr(
+        "Workroom ID and Channel ID are required to enable the loop.",
+        "启用循环需要填写工作室 ID 与频道 ID。"
+    ) }
+
+    // Config errors (MioAgentEnroller.ConfigError)
+    static var agentEnrollErrConfigMissing: String { tr(
+        "~/.mio/agent.json not found. Enroll the workspace first.",
+        "未找到 ~/.mio/agent.json。请先注册工作区。"
+    ) }
+    static func agentEnrollErrConfigMalformed(_ msg: String) -> String {
+        tr("agent.json is malformed: \(msg)", "agent.json 格式错误：\(msg)")
+    }
+    static func agentEnrollErrConfigWrite(_ msg: String) -> String {
+        tr("Could not write agent.json: \(msg)", "无法写入 agent.json：\(msg)")
     }
 }

--- a/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
@@ -10,11 +10,13 @@ import CryptoKit
 //   version, git_commit, platforms.<arch>.{file, sha256, size}, required_fixes, created_at
 //
 // Install flow (task #121):
-//   1. Fetch SHASUMS256.txt from the pinned release tag
-//   2. Download the darwin-arm64 tarball
-//   3. Verify SHA-256 against the manifest value
-//   4. Extract binary from tarball with /usr/bin/tar
-//   5. Atomically move to ~/.mio/bin/mio-agent (never overwrites on failure)
+//   1. Fetch manifest JSON; assert required_fixes ⊇ {machine-api-v1-prefix, socketio-control-path}
+//      (anti-rollback gate from task #118/#120 — rejects stale releases even if SHA matches)
+//   2. Fetch SHASUMS256.txt from the pinned release tag
+//   3. Download the darwin-arm64 tarball
+//   4. Verify SHA-256 against SHASUMS256.txt value
+//   5. Extract binary from tarball with /usr/bin/tar
+//   6. Copy to dest.staging, then FileManager.replaceItemAt (atomic; old binary survives failure)
 //
 // Update procedure when cutting a new release:
 //   - Run `npm run build:release` in mio-agent (scripts/build-release.mjs)
@@ -48,9 +50,28 @@ enum MioAgentDistribution {
     static var shasumURL:    URL { releaseBaseURL.appendingPathComponent("SHASUMS256.txt") }
     static var tarballURL:   URL { releaseBaseURL.appendingPathComponent(tarballFilename) }
 
+    // ── Anti-rollback contract (task #118/#120) ───────────────────────────────
+
+    /// Fixes that MUST be present in a release's manifest before we allow installation.
+    /// A release that pre-dates these fixes is rejected even if its SHA-256 matches.
+    static let requiredFixes: Set<String> = [
+        "machine-api-v1-prefix",
+        "socketio-control-path",
+    ]
+
+    // ── Manifest type ─────────────────────────────────────────────────────────
+
+    /// Subset of the release manifest we care about for install-time validation.
+    private struct Manifest: Decodable {
+        let version: String
+        let required_fixes: [String]
+    }
+
     // ── Error types ───────────────────────────────────────────────────────────
 
     enum DownloadError: LocalizedError {
+        case manifestFetchFailed(statusCode: Int)
+        case requiredFixesMissing(fixes: [String])
         case shasumFetchFailed(statusCode: Int)
         case sha256NotFound(filename: String)
         case downloadFailed(statusCode: Int)
@@ -60,6 +81,11 @@ enum MioAgentDistribution {
 
         var errorDescription: String? {
             switch self {
+            case .manifestFetchFailed(let code):
+                return "Failed to fetch release manifest (HTTP \(code))"
+            case .requiredFixesMissing(let fixes):
+                return "Release is missing required fixes: \(fixes.joined(separator: ", ")). " +
+                       "This release is too old to install safely — update pinnedVersion."
             case .shasumFetchFailed(let code):
                 return "Failed to fetch release checksum file (HTTP \(code))"
             case .sha256NotFound(let filename):
@@ -97,7 +123,28 @@ enum MioAgentDistribution {
         onProgress: @escaping @Sendable (String) -> Void
     ) async throws {
 
-        // ── Step 1: Fetch SHASUMS256.txt for SHA-256 of the tarball ──
+        // ── Step 1: Fetch and validate release manifest ──
+        //
+        // The manifest carries a `required_fixes` array that lists all bug-fixes
+        // present in this release. We reject any release that is missing the
+        // mandatory fixes from task #118/#120 — even if its SHA-256 matches —
+        // to prevent a pinned-but-stale release from installing a buggy daemon.
+
+        onProgress("Verifying release manifest...")
+        let (manifestData, manifestResp) = try await URLSession.shared.data(from: manifestURL)
+        let manifestStatus = (manifestResp as? HTTPURLResponse)?.statusCode ?? 0
+        guard manifestStatus == 200 else {
+            throw DownloadError.manifestFetchFailed(statusCode: manifestStatus)
+        }
+
+        let manifest = try JSONDecoder().decode(Manifest.self, from: manifestData)
+        let presentFixes = Set(manifest.required_fixes)
+        let missingFixes = Self.requiredFixes.subtracting(presentFixes)
+        guard missingFixes.isEmpty else {
+            throw DownloadError.requiredFixesMissing(fixes: Array(missingFixes).sorted())
+        }
+
+        // ── Step 2: Fetch SHASUMS256.txt for SHA-256 of the tarball ──
 
         onProgress("Fetching release checksum...")
         let (shasumData, shasumResp) = try await URLSession.shared.data(from: shasumURL)
@@ -111,7 +158,7 @@ enum MioAgentDistribution {
             throw DownloadError.sha256NotFound(filename: tarballFilename)
         }
 
-        // ── Step 2: Download tarball to a per-install temp directory ──
+        // ── Step 3: Download tarball to a per-install temp directory ──
 
         let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("mio-agent-install-\(UUID().uuidString)")
@@ -129,7 +176,7 @@ enum MioAgentDistribution {
         // Move URLSession's temp file into our named temp location.
         try FileManager.default.moveItem(at: downloadedURL, to: tempTarball)
 
-        // ── Step 3: Verify SHA-256 before touching the destination ──
+        // ── Step 4: Verify SHA-256 before touching the destination ──
 
         onProgress("Verifying checksum...")
         let tarballData = try Data(contentsOf: tempTarball)
@@ -140,7 +187,7 @@ enum MioAgentDistribution {
             throw DownloadError.checksumMismatch(expected: expectedSHA256, actual: actualSHA256)
         }
 
-        // ── Step 4: Extract binary from tarball ──
+        // ── Step 5: Extract binary from tarball ──
 
         onProgress("Extracting binary...")
         let extractDir = tempDir.appendingPathComponent("extract")
@@ -154,27 +201,47 @@ enum MioAgentDistribution {
             throw DownloadError.extractionFailed(reason: tarErr.isEmpty ? "tar exited \(tarExit)" : tarErr)
         }
 
-        // ── Step 5: Locate the binary inside the extracted tree ──
+        // ── Step 6: Locate the binary inside the extracted tree ──
 
         guard let extractedBinary = findFile(named: "mio-agent", in: extractDir) else {
             throw DownloadError.binaryNotFoundInTarball
         }
 
-        // ── Step 6: Atomic move to destination (no-overwrite-on-fail) ──
+        // ── Step 7: Stage-then-atomic-replace (true no-overwrite-on-fail) ──
         //
-        // We only touch destinationPath AFTER all verification passes.
-        // If we throw before this step, the old binary is preserved.
+        // We copy the verified binary to a sibling staging path first.
+        // The OLD binary at destinationPath is NEVER removed until the staging
+        // copy is complete and the atomic swap succeeds. On any failure before
+        // the swap, the old binary is intact.
+        //
+        // FileManager.replaceItemAt(_:withItemAt:) maps to renameat(2) on the
+        // same volume — atomic on HFS+/APFS. It also handles the case where
+        // the destination does not yet exist (first install).
+        //
+        // Note on codesigning: ad-hoc re-signing (--sign -) is harmless for the
+        // current ad-hoc-signed release. If the release ships with a Developer-ID
+        // signature in future, callers MUST NOT ad-hoc re-sign — doing so will
+        // strip the notarisation seal. Caller should probe the existing signature
+        // before deciding whether to sign.
 
         onProgress("Installing mio-agent...")
         let destURL = URL(fileURLWithPath: destinationPath)
+        let stagingURL = URL(fileURLWithPath: destinationPath + ".staging")
 
-        // Remove existing binary so we can move the new one in cleanly.
+        // Remove any leftover staging file from a previous failed attempt.
+        try? FileManager.default.removeItem(at: stagingURL)
+
+        // Copy verified binary into staging (old dest is untouched on failure here).
+        try FileManager.default.copyItem(at: extractedBinary, to: stagingURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: stagingURL.path)
+
+        // Atomic swap: old binary survives until this line returns successfully.
         if FileManager.default.fileExists(atPath: destinationPath) {
-            try FileManager.default.removeItem(at: destURL)
+            _ = try FileManager.default.replaceItemAt(destURL, withItemAt: stagingURL)
+        } else {
+            // First install — no existing binary to preserve; just move staging into place.
+            try FileManager.default.moveItem(at: stagingURL, to: destURL)
         }
-        // Copy (not move) so the verified file stays in temp until FileManager confirms success.
-        try FileManager.default.copyItem(at: extractedBinary, to: destURL)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationPath)
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
@@ -41,6 +41,12 @@ enum MioAgentDistribution {
         "mio-agent-\(pinnedVersion)-darwin-arm64.tar.gz"
     }
 
+    /// Name of the SEA binary INSIDE the tarball (build-release.mjs packs it as this name).
+    /// Keep in sync with `seaBinary` in scripts/build-release.mjs in the mio-agent repo.
+    static var binaryFilename: String {
+        "mio-agent-\(pinnedVersion)-darwin-arm64"
+    }
+
     /// GitHub Releases base URL for the pinned release tag.
     static var releaseBaseURL: URL {
         URL(string: "https://github.com/\(repoOwner)/\(repoName)/releases/download/v\(pinnedVersion)/")!
@@ -116,8 +122,12 @@ enum MioAgentDistribution {
     ///
     /// Caller is responsible for:
     ///   - Creating parent directories before calling this function.
-    ///   - Ad-hoc codesigning the installed binary (required for launchd/Keychain on Apple Silicon).
-    ///   - Writing the LaunchAgent plist and calling launchctl bootstrap after install succeeds.
+    ///   - Codesigning the installed binary. For the current ad-hoc-signed release,
+    ///     `codesign --sign - --force <path>` is harmless. If the release ships a
+    ///     Developer-ID signature in future, probe the existing signature first —
+    ///     do NOT ad-hoc re-sign (it strips the notarisation seal).
+    ///   - Writing the LaunchAgent plist and calling `launchctl bootstrap gui/<uid>`
+    ///     (NOT `user/<uid>` — that is the #114/#79 domain bug) after install succeeds.
     static func downloadAndInstall(
         to destinationPath: String,
         onProgress: @escaping @Sendable (String) -> Void
@@ -202,8 +212,11 @@ enum MioAgentDistribution {
         }
 
         // ── Step 6: Locate the binary inside the extracted tree ──
+        //
+        // build-release.mjs packs the SEA binary as "mio-agent-<ver>-darwin-arm64"
+        // (NOT plain "mio-agent"). Use binaryFilename to match the actual name.
 
-        guard let extractedBinary = findFile(named: "mio-agent", in: extractDir) else {
+        guard let extractedBinary = findFile(named: binaryFilename, in: extractDir) else {
             throw DownloadError.binaryNotFoundInTarball
         }
 

--- a/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
@@ -1,0 +1,233 @@
+import Foundation
+import CryptoKit
+
+// MARK: - MioAgentDistribution
+//
+// Download-at-install distribution for the mio-agent daemon binary.
+//
+// Release artifacts live on GitHub Releases (MioMioOS/mio-agent).
+// The manifest (mio-agent-<ver>-manifest.json) carries:
+//   version, git_commit, platforms.<arch>.{file, sha256, size}, required_fixes, created_at
+//
+// Install flow (task #121):
+//   1. Fetch SHASUMS256.txt from the pinned release tag
+//   2. Download the darwin-arm64 tarball
+//   3. Verify SHA-256 against the manifest value
+//   4. Extract binary from tarball with /usr/bin/tar
+//   5. Atomically move to ~/.mio/bin/mio-agent (never overwrites on failure)
+//
+// Update procedure when cutting a new release:
+//   - Run `npm run build:release` in mio-agent (scripts/build-release.mjs)
+//   - Publish GitHub Release with dist/release/ artifacts
+//   - Update pinnedVersion + pinnedSHA256 below (from SHASUMS256.txt)
+//
+// Security: SHA-256 is fetched from SHASUMS256.txt at download time.
+// For future hardening, pin sha256 as a build-time constant here.
+
+enum MioAgentDistribution {
+
+    // ── Release pin ───────────────────────────────────────────────────────────
+
+    /// Pinned release version. Update when cutting a new mio-agent release.
+    static let pinnedVersion = "0.1.0"
+
+    static let repoOwner = "MioMioOS"
+    static let repoName  = "mio-agent"
+
+    /// darwin-arm64 tarball filename for the pinned release.
+    static var tarballFilename: String {
+        "mio-agent-\(pinnedVersion)-darwin-arm64.tar.gz"
+    }
+
+    /// GitHub Releases base URL for the pinned release tag.
+    static var releaseBaseURL: URL {
+        URL(string: "https://github.com/\(repoOwner)/\(repoName)/releases/download/v\(pinnedVersion)/")!
+    }
+
+    static var manifestURL:  URL { releaseBaseURL.appendingPathComponent("mio-agent-\(pinnedVersion)-manifest.json") }
+    static var shasumURL:    URL { releaseBaseURL.appendingPathComponent("SHASUMS256.txt") }
+    static var tarballURL:   URL { releaseBaseURL.appendingPathComponent(tarballFilename) }
+
+    // ── Error types ───────────────────────────────────────────────────────────
+
+    enum DownloadError: LocalizedError {
+        case shasumFetchFailed(statusCode: Int)
+        case sha256NotFound(filename: String)
+        case downloadFailed(statusCode: Int)
+        case checksumMismatch(expected: String, actual: String)
+        case extractionFailed(reason: String)
+        case binaryNotFoundInTarball
+
+        var errorDescription: String? {
+            switch self {
+            case .shasumFetchFailed(let code):
+                return "Failed to fetch release checksum file (HTTP \(code))"
+            case .sha256NotFound(let filename):
+                return "SHA-256 entry for '\(filename)' not found in SHASUMS256.txt"
+            case .downloadFailed(let code):
+                return "Binary download failed (HTTP \(code))"
+            case .checksumMismatch(let expected, let actual):
+                return "Checksum mismatch — expected \(expected.prefix(12))…, got \(actual.prefix(12))…"
+            case .extractionFailed(let reason):
+                return "Tarball extraction failed: \(reason)"
+            case .binaryNotFoundInTarball:
+                return "mio-agent binary not found inside the downloaded tarball"
+            }
+        }
+    }
+
+    // ── Public install entry point ────────────────────────────────────────────
+
+    /// Download, verify, extract, and atomically install the mio-agent binary.
+    ///
+    /// - Parameters:
+    ///   - destinationPath: Target path for the installed binary (e.g. ~/.mio/bin/mio-agent).
+    ///   - onProgress: Called with a human-readable status string at each stage (called on
+    ///     a background thread; caller must dispatch to main actor if needed).
+    ///
+    /// - Throws: `DownloadError` on any failure.
+    ///   On failure the destination binary is NOT overwritten (no-overwrite-on-fail contract).
+    ///
+    /// Caller is responsible for:
+    ///   - Creating parent directories before calling this function.
+    ///   - Ad-hoc codesigning the installed binary (required for launchd/Keychain on Apple Silicon).
+    ///   - Writing the LaunchAgent plist and calling launchctl bootstrap after install succeeds.
+    static func downloadAndInstall(
+        to destinationPath: String,
+        onProgress: @escaping @Sendable (String) -> Void
+    ) async throws {
+
+        // ── Step 1: Fetch SHASUMS256.txt for SHA-256 of the tarball ──
+
+        onProgress("Fetching release checksum...")
+        let (shasumData, shasumResp) = try await URLSession.shared.data(from: shasumURL)
+        let shasumStatus = (shasumResp as? HTTPURLResponse)?.statusCode ?? 0
+        guard shasumStatus == 200 else {
+            throw DownloadError.shasumFetchFailed(statusCode: shasumStatus)
+        }
+
+        let shasumText = String(data: shasumData, encoding: .utf8) ?? ""
+        guard let expectedSHA256 = parseSHA256(from: shasumText, for: tarballFilename) else {
+            throw DownloadError.sha256NotFound(filename: tarballFilename)
+        }
+
+        // ── Step 2: Download tarball to a per-install temp directory ──
+
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mio-agent-install-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        // Always clean up the temp directory, even on failure.
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        onProgress("Downloading mio-agent \(pinnedVersion)...")
+        let tempTarball = tempDir.appendingPathComponent(tarballFilename)
+        let (downloadedURL, downloadResp) = try await URLSession.shared.download(from: tarballURL)
+        let downloadStatus = (downloadResp as? HTTPURLResponse)?.statusCode ?? 0
+        guard downloadStatus == 200 else {
+            throw DownloadError.downloadFailed(statusCode: downloadStatus)
+        }
+        // Move URLSession's temp file into our named temp location.
+        try FileManager.default.moveItem(at: downloadedURL, to: tempTarball)
+
+        // ── Step 3: Verify SHA-256 before touching the destination ──
+
+        onProgress("Verifying checksum...")
+        let tarballData = try Data(contentsOf: tempTarball)
+        let actualSHA256 = SHA256.hash(data: tarballData)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        guard actualSHA256 == expectedSHA256 else {
+            throw DownloadError.checksumMismatch(expected: expectedSHA256, actual: actualSHA256)
+        }
+
+        // ── Step 4: Extract binary from tarball ──
+
+        onProgress("Extracting binary...")
+        let extractDir = tempDir.appendingPathComponent("extract")
+        try FileManager.default.createDirectory(at: extractDir, withIntermediateDirectories: true)
+
+        let (tarExit, tarErr) = try await runProcess(
+            "/usr/bin/tar",
+            args: ["-xzf", tempTarball.path, "-C", extractDir.path]
+        )
+        guard tarExit == 0 else {
+            throw DownloadError.extractionFailed(reason: tarErr.isEmpty ? "tar exited \(tarExit)" : tarErr)
+        }
+
+        // ── Step 5: Locate the binary inside the extracted tree ──
+
+        guard let extractedBinary = findFile(named: "mio-agent", in: extractDir) else {
+            throw DownloadError.binaryNotFoundInTarball
+        }
+
+        // ── Step 6: Atomic move to destination (no-overwrite-on-fail) ──
+        //
+        // We only touch destinationPath AFTER all verification passes.
+        // If we throw before this step, the old binary is preserved.
+
+        onProgress("Installing mio-agent...")
+        let destURL = URL(fileURLWithPath: destinationPath)
+
+        // Remove existing binary so we can move the new one in cleanly.
+        if FileManager.default.fileExists(atPath: destinationPath) {
+            try FileManager.default.removeItem(at: destURL)
+        }
+        // Copy (not move) so the verified file stays in temp until FileManager confirms success.
+        try FileManager.default.copyItem(at: extractedBinary, to: destURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationPath)
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /// Parse a SHASUMS256.txt file (coreutils format: "<hex>  <filename>").
+    /// Matches both bare filename and path-prefixed entries (e.g. "dir/file.tar.gz").
+    private static func parseSHA256(from text: String, for filename: String) -> String? {
+        for line in text.split(separator: "\n") {
+            let parts = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard parts.count >= 2 else { continue }
+            let hash = String(parts[0])
+            let entry = String(parts.last!)
+            if entry == filename || entry.hasSuffix("/\(filename)") {
+                return hash
+            }
+        }
+        return nil
+    }
+
+    /// Recursively find the first regular file named `name` under `directory`.
+    private static func findFile(named name: String, in directory: URL) -> URL? {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else { return nil }
+
+        for case let url as URL in enumerator {
+            guard url.lastPathComponent == name else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            if values?.isRegularFile == true { return url }
+        }
+        return nil
+    }
+
+    /// Run a process synchronously, capturing stderr. Returns (exitCode, stderrText).
+    private static func runProcess(_ executable: String, args: [String]) async throws -> (Int32, String) {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = args
+            process.standardOutput = FileHandle.nullDevice
+            let errPipe = Pipe()
+            process.standardError = errPipe
+            do {
+                try process.run()
+                process.waitUntilExit()
+                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                let errStr = String(data: errData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                continuation.resume(returning: (process.terminationStatus, errStr))
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentDistribution.swift
@@ -31,7 +31,10 @@ enum MioAgentDistribution {
     // ── Release pin ───────────────────────────────────────────────────────────
 
     /// Pinned release version. Update when cutting a new mio-agent release.
-    static let pinnedVersion = "0.1.0"
+    /// Drives BOTH the GitHub-binary download AND the npx-cached launch
+    /// (MioAgentLauncher.npmSpec = `@miomioos/mio-agent@<pinnedVersion>`), so the
+    /// two distribution paths always run the same release.
+    static let pinnedVersion = "0.2.3"
 
     static let repoOwner = "MioMioOS"
     static let repoName  = "mio-agent"

--- a/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
@@ -90,6 +90,13 @@ final class MioAgentEnroller: ObservableObject {
     var binaryExists: Bool { FileManager.default.fileExists(atPath: binaryPath) }
     var configExists: Bool { FileManager.default.fileExists(atPath: configPath) }
 
+    /// Enrollment is launchable when EITHER npx-cached OR an installed binary is
+    /// present (task #117). npx makes the GitHub-binary download optional.
+    var canEnroll: Bool {
+        if case .success = MioAgentLauncher.resolve() { return true }
+        return false
+    }
+
     // MARK: - Enroll (shell out to `mio-agent login`)
 
     /// Launch `mio-agent login --server <url> --device-name <name>`.
@@ -99,8 +106,13 @@ final class MioAgentEnroller: ObservableObject {
     ///   caller can refresh the dual QR to embed this exact intent.
     /// - Re-runnable: cancels any in-flight login first.
     func startEnrollment(serverUrl: String, deviceName: String, onIntent: @escaping (MioEnrollIntent) -> Void) {
-        guard binaryExists else {
-            phase = .failed(L10n.agentEnrollErrNoBinary)
+        // Resolve npx-cached first, installed binary as fallback (#117). If neither
+        // is available, fail with a clear message rather than silently no-op.
+        let launch: MioAgentLauncher.Launch
+        switch MioAgentLauncher.resolve() {
+        case .success(let l): launch = l
+        case .failure:
+            phase = .failed(L10n.agentEnrollErrNoLauncher)
             return
         }
         // Tear down any previous attempt cleanly.
@@ -111,8 +123,10 @@ final class MioAgentEnroller: ObservableObject {
         lastLine = ""
 
         let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: binaryPath)
-        proc.arguments = ["login", "--server", serverUrl, "--device-name", deviceName]
+        proc.executableURL = URL(fileURLWithPath: launch.executablePath)
+        proc.arguments = launch.prefixArgs + ["login", "--server", serverUrl, "--device-name", deviceName]
+        proc.environment = MioAgentLauncher.childEnvironment(for: launch)
+        Self.logger.info("Enroll via \(String(describing: launch.kind), privacy: .public) launcher: \(launch.executablePath, privacy: .public)")
 
         let outPipe = Pipe()
         let errPipe = Pipe()
@@ -124,18 +138,19 @@ final class MioAgentEnroller: ObservableObject {
         // tail of the most recent line for the UI.
         outPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
-            guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
-            Task { @MainActor in self?.ingest(chunk, onIntent: onIntent) }
+            guard let self, !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+            Task { @MainActor in self.ingest(chunk, onIntent: onIntent) }
         }
         errPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             let data = handle.availableData
-            guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
-            Task { @MainActor in self?.ingest(chunk, onIntent: onIntent) }
+            guard let self, !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+            Task { @MainActor in self.ingest(chunk, onIntent: onIntent) }
         }
 
         proc.terminationHandler = { [weak self] p in
             let code = p.terminationStatus
-            Task { @MainActor in self?.handleTermination(exitCode: code) }
+            guard let self else { return }
+            Task { @MainActor in self.handleTermination(exitCode: code) }
         }
 
         do {
@@ -147,6 +162,44 @@ final class MioAgentEnroller: ObservableObject {
         } catch {
             phase = .failed(L10n.agentEnrollErrLaunch(error.localizedDescription))
             Self.logger.error("Failed to launch mio-agent login: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - One QR = both (task #118)
+
+    /// Proactively create a workspace enrollment intent so the Pair-iPhone QR
+    /// carries BOTH monitoring AND workspace by default — one scan does everything.
+    ///
+    /// Called when a QR surface appears. It only starts a silent enrollment when:
+    ///   - the daemon is launchable (npx-cached or installed binary), AND
+    ///   - this Mac is NOT already enrolled (agent.json absent), AND
+    ///   - no enrollment is already in flight (idle phase, no intent), AND
+    ///   - a server URL is known.
+    /// Otherwise it is a no-op and the QR degrades to monitor-only — never blocking
+    /// the common monitoring-pair case behind workspace setup.
+    ///
+    /// `mio-agent login` long-polls the intent it prints; the phone approving the
+    /// intent embedded in the QR resolves that same poll. If the QR window closes
+    /// without a scan, the in-flight login is cancelled (see QR surface onDisappear).
+    func ensureWorkspaceIntentForQR(serverUrl: String?) {
+        guard let server = serverUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !server.isEmpty else { return }
+        // NOTE: do NOT gate on `configExists`. A stale/archived enrollment (or simply wanting
+        // to re-associate to another account/workspace) must still be re-pairable by scanning —
+        // "already enrolled" is not a reason to refuse a fresh QR. Re-scanning re-associates.
+        // Already have a fresh intent or an enrollment in flight → nothing to do (avoid spawning
+        // a second login each time the QR surface re-appears in the same session).
+        guard intent == nil, phase == .idle else { return }
+        // Daemon not launchable → can't create an intent; QR stays monitor-only.
+        guard canEnroll else { return }
+
+        Self.logger.info("Auto-starting workspace enrollment for one-QR-both (#118)")
+        startEnrollment(
+            serverUrl: server,
+            deviceName: Host.current().localizedName ?? "Mac"
+        ) { _ in
+            // Intent parsed — the QR surfaces observing `intent` re-render into
+            // kind:"both" automatically.
         }
     }
 

--- a/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
@@ -1,0 +1,356 @@
+//
+//  MioAgentEnroller.swift
+//  ClaudeIsland
+//
+//  R2.1 — In-app machine enrollment by SHELLING OUT to the installed
+//  `mio-agent` binary. We run `mio-agent login --server <url> --device-name
+//  <name>` via Process and let the binary itself write the macOS Keychain
+//  (machine_token) + ~/.mio/agent.json. We do NOT reimplement Keychain or the
+//  enrollment protocol — that is the whole point of shelling out.
+//
+//  Coordination with the dual QR (R2.7):
+//    `mio-agent login` creates its OWN enrollment intent server-side and prints
+//    a `mio://enroll/<intent_id>?code=…&server=…` deeplink to stdout, then
+//    long-polls GET /api/v1/enrollment-intents/:id until the phone approves.
+//    We parse that deeplink off login's stdout to learn the SAME intent_id +
+//    opaque_code the binary is polling, and surface them so the monitoring QR
+//    can embed them (kind: "both"). The phone then approves THAT intent, login's
+//    poll resolves, and login writes Keychain + agent.json. One scan, both jobs.
+//
+//  The autonomous_agent block of agent.json is plain JSON (no Keychain), so the
+//  optional autonomous-agent editor merges it into the login-written agent.json
+//  in place, preserving every field login wrote.
+//
+
+import Combine
+import Foundation
+import os.log
+
+// MARK: - Enroll phase (UI-facing state machine)
+
+/// Phases of the in-app enrollment shell-out. Drives the enroll card UI.
+enum MioEnrollPhase: Equatable {
+    /// No enrollment in progress.
+    case idle
+    /// `mio-agent login` launched; waiting for it to print the deeplink.
+    case launching
+    /// Deeplink parsed; QR is live; long-polling for phone approval.
+    case awaitingApproval
+    /// login exited 0 — Keychain + agent.json written by the binary.
+    case succeeded
+    /// login exited non-zero, timed out, or could not be launched.
+    case failed(String)
+
+    var isActive: Bool {
+        switch self {
+        case .launching, .awaitingApproval: return true
+        default: return false
+        }
+    }
+}
+
+/// The enrollment intent parsed from `mio-agent login` stdout. These are the
+/// values the binary is actively long-polling, so embedding them in the
+/// monitoring QR guarantees the phone approves the intent login is watching.
+struct MioEnrollIntent: Equatable {
+    let intentId: String
+    let opaqueCode: String
+    /// Full `mio://enroll/...` deeplink, kept for the paste-into-Safari fallback.
+    let deeplink: String
+}
+
+// MARK: - MioAgentEnroller
+
+/// Owns the `mio-agent login` subprocess lifecycle and parses its output.
+/// `@MainActor` so its `@Published` state drives SwiftUI directly.
+@MainActor
+final class MioAgentEnroller: ObservableObject {
+
+    static let shared = MioAgentEnroller()
+    static let logger = Logger(subsystem: "com.codeisland", category: "MioAgentEnroller")
+
+    @Published private(set) var phase: MioEnrollPhase = .idle
+    /// Parsed enrollment intent (intent_id + opaque_code) once login prints it.
+    @Published private(set) var intent: MioEnrollIntent?
+    /// Tail of login stdout/stderr (for the in-app diagnostic line). Capped.
+    @Published private(set) var lastLine: String = ""
+
+    /// The installed binary path — same location MioAgentDistribution installs to.
+    let binaryPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".mio/bin/mio-agent").path
+    let configPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".mio/agent.json").path
+
+    private var process: Process?
+    private var outPipe: Pipe?
+    private var errPipe: Pipe?
+
+    private init() {}
+
+    var binaryExists: Bool { FileManager.default.fileExists(atPath: binaryPath) }
+    var configExists: Bool { FileManager.default.fileExists(atPath: configPath) }
+
+    // MARK: - Enroll (shell out to `mio-agent login`)
+
+    /// Launch `mio-agent login --server <url> --device-name <name>`.
+    ///
+    /// - The binary owns Keychain + agent.json. We only orchestrate + observe.
+    /// - `onIntent` fires once the `mio://enroll/...` deeplink is parsed, so the
+    ///   caller can refresh the dual QR to embed this exact intent.
+    /// - Re-runnable: cancels any in-flight login first.
+    func startEnrollment(serverUrl: String, deviceName: String, onIntent: @escaping (MioEnrollIntent) -> Void) {
+        guard binaryExists else {
+            phase = .failed(L10n.agentEnrollErrNoBinary)
+            return
+        }
+        // Tear down any previous attempt cleanly.
+        cancelEnrollment()
+
+        phase = .launching
+        intent = nil
+        lastLine = ""
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binaryPath)
+        proc.arguments = ["login", "--server", serverUrl, "--device-name", deviceName]
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+
+        // Stream stdout line by line. login prints the deeplink early, then
+        // emits progress lines while polling; we parse the deeplink and keep a
+        // tail of the most recent line for the UI.
+        outPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+            Task { @MainActor in self?.ingest(chunk, onIntent: onIntent) }
+        }
+        errPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let chunk = String(data: data, encoding: .utf8) else { return }
+            Task { @MainActor in self?.ingest(chunk, onIntent: onIntent) }
+        }
+
+        proc.terminationHandler = { [weak self] p in
+            let code = p.terminationStatus
+            Task { @MainActor in self?.handleTermination(exitCode: code) }
+        }
+
+        do {
+            try proc.run()
+            self.process = proc
+            self.outPipe = outPipe
+            self.errPipe = errPipe
+            Self.logger.info("mio-agent login launched (server=\(serverUrl, privacy: .public) name=\(deviceName, privacy: .public))")
+        } catch {
+            phase = .failed(L10n.agentEnrollErrLaunch(error.localizedDescription))
+            Self.logger.error("Failed to launch mio-agent login: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Cancel an in-flight enrollment. Terminates the polling subprocess so it
+    /// stops holding the (now stale) intent open. Safe to call when idle.
+    func cancelEnrollment() {
+        if let p = process, p.isRunning {
+            p.terminationHandler = nil
+            p.terminate()
+        }
+        detachPipeHandlers()
+        process = nil
+        if phase.isActive { phase = .idle }
+    }
+
+    /// Null out the readability handlers and drop pipe references so they don't
+    /// fire on EOF after the subprocess ends (a common Process/Pipe pitfall).
+    private func detachPipeHandlers() {
+        outPipe?.fileHandleForReading.readabilityHandler = nil
+        errPipe?.fileHandleForReading.readabilityHandler = nil
+        outPipe = nil
+        errPipe = nil
+    }
+
+    /// Reset back to idle after a terminal phase, so the card can be reused.
+    func reset() {
+        cancelEnrollment()
+        phase = .idle
+        intent = nil
+        lastLine = ""
+    }
+
+    // MARK: - Output ingestion
+
+    private func ingest(_ chunk: String, onIntent: @escaping (MioEnrollIntent) -> Void) {
+        for rawLine in chunk.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            lastLine = String(line.prefix(240))
+
+            // Parse the deeplink the first time we see it. login prints it both
+            // standalone and inside the "(or paste this URL …)" hint line, so we
+            // scan for the `mio://enroll/` substring anywhere on the line.
+            if intent == nil, let parsed = Self.parseEnrollDeeplink(from: line) {
+                intent = parsed
+                if phase == .launching { phase = .awaitingApproval }
+                Self.logger.info("Parsed enroll intent \(parsed.intentId.prefix(8), privacy: .public) from login output")
+                onIntent(parsed)
+            }
+        }
+    }
+
+    private func handleTermination(exitCode: Int32) {
+        detachPipeHandlers()
+        process = nil
+        if exitCode == 0 {
+            phase = .succeeded
+            Self.logger.info("mio-agent login succeeded — Keychain + agent.json written by the binary")
+        } else {
+            // Prefer the captured tail (login prints a human-readable error on
+            // its last line for timeouts / 403 / network errors).
+            let detail = lastLine.isEmpty ? L10n.agentEnrollErrExit(exitCode) : lastLine
+            phase = .failed(detail)
+            Self.logger.error("mio-agent login exited \(exitCode): \(detail, privacy: .public)")
+        }
+    }
+
+    // MARK: - Deeplink parsing
+
+    /// Extract intent_id + opaque_code from a `mio://enroll/<id>?code=…&server=…`
+    /// deeplink embedded anywhere in `line`. Returns nil if no valid deeplink.
+    static func parseEnrollDeeplink(from line: String) -> MioEnrollIntent? {
+        guard let range = line.range(of: "mio://enroll/") else { return nil }
+        // The deeplink runs from the scheme to the first whitespace or closing
+        // paren (login wraps it in "(... )"). Slice from the marker to that edge.
+        var tail = String(line[range.lowerBound...])
+        if let stop = tail.firstIndex(where: { $0 == " " || $0 == ")" || $0 == "\t" }) {
+            tail = String(tail[tail.startIndex..<stop])
+        }
+        let deeplink = tail
+
+        // mio://enroll/<intentId>?code=<code>&server=…
+        guard let afterScheme = deeplink.range(of: "mio://enroll/") else { return nil }
+        let rest = String(deeplink[afterScheme.upperBound...])
+        guard let qMark = rest.firstIndex(of: "?") else { return nil }
+        let intentId = String(rest[rest.startIndex..<qMark])
+        guard !intentId.isEmpty else { return nil }
+
+        let queryString = String(rest[rest.index(after: qMark)...])
+        var code: String?
+        for pair in queryString.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1).map(String.init)
+            guard kv.count == 2 else { continue }
+            if kv[0] == "code" {
+                code = kv[1].removingPercentEncoding ?? kv[1]
+            }
+        }
+        guard let opaqueCode = code, !opaqueCode.isEmpty else { return nil }
+
+        return MioEnrollIntent(intentId: intentId, opaqueCode: opaqueCode, deeplink: deeplink)
+    }
+
+    // MARK: - Autonomous agent block (plain JSON merge into agent.json)
+
+    /// The optional autonomous_agent loop config, mirrors AutonomousAgentConfig
+    /// in mio-agent src/config/types.ts. Default-off semantics: `enabled:false`
+    /// or an absent block means the loop does not start.
+    struct AutonomousAgentBlock: Codable, Equatable {
+        var enabled: Bool
+        var workroom_id: String
+        var channel_id: String
+        var handle: String
+        var quiet_seconds: Int
+        var max_replies_per_window: Int
+        var window_seconds: Int
+
+        static let defaults = AutonomousAgentBlock(
+            enabled: false,
+            workroom_id: "",
+            channel_id: "",
+            handle: "@agent",
+            quiet_seconds: 30,
+            max_replies_per_window: 8,
+            window_seconds: 600
+        )
+    }
+
+    enum ConfigError: LocalizedError {
+        case notConfigured
+        case malformed(String)
+        case writeFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notConfigured: return L10n.agentEnrollErrConfigMissing
+            case .malformed(let m): return L10n.agentEnrollErrConfigMalformed(m)
+            case .writeFailed(let m): return L10n.agentEnrollErrConfigWrite(m)
+            }
+        }
+    }
+
+    /// Read the current autonomous_agent block from agent.json, if present.
+    /// Returns nil when agent.json exists but carries no autonomous_agent block.
+    func readAutonomousBlock() throws -> AutonomousAgentBlock? {
+        guard configExists else { throw ConfigError.notConfigured }
+        let data: Data
+        do { data = try Data(contentsOf: URL(fileURLWithPath: configPath)) }
+        catch { throw ConfigError.malformed(error.localizedDescription) }
+
+        guard let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            throw ConfigError.malformed("agent.json is not a JSON object")
+        }
+        guard let block = root["autonomous_agent"] as? [String: Any] else { return nil }
+        let blockData = try JSONSerialization.data(withJSONObject: block)
+        return try? JSONDecoder().decode(AutonomousAgentBlock.self, from: blockData)
+    }
+
+    /// Merge `block` into agent.json's `autonomous_agent` key WITHOUT disturbing
+    /// any other field login wrote (machine_id, org_id, keychain_item_ref, …).
+    /// Re-reads the file, mutates one key, re-serializes, writes 0600.
+    func writeAutonomousBlock(_ block: AutonomousAgentBlock) throws {
+        guard configExists else { throw ConfigError.notConfigured }
+        let url = URL(fileURLWithPath: configPath)
+        let data: Data
+        do { data = try Data(contentsOf: url) }
+        catch { throw ConfigError.malformed(error.localizedDescription) }
+
+        guard var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            throw ConfigError.malformed("agent.json is not a JSON object")
+        }
+
+        let blockData = try JSONEncoder().encode(block)
+        guard let blockDict = (try? JSONSerialization.jsonObject(with: blockData)) as? [String: Any] else {
+            throw ConfigError.malformed("could not serialize autonomous_agent block")
+        }
+        root["autonomous_agent"] = blockDict
+
+        do {
+            let out = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            try out.write(to: url, options: .atomic)
+            // Preserve the 0600 mode login set (atomic write can reset perms).
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configPath)
+        } catch {
+            throw ConfigError.writeFailed(error.localizedDescription)
+        }
+        Self.logger.info("Merged autonomous_agent block into agent.json (enabled=\(block.enabled, privacy: .public))")
+    }
+
+    /// Remove the autonomous_agent block entirely (returns the daemon to
+    /// default-off without leaving an `enabled:false` stub).
+    func clearAutonomousBlock() throws {
+        guard configExists else { throw ConfigError.notConfigured }
+        let url = URL(fileURLWithPath: configPath)
+        guard let data = try? Data(contentsOf: url),
+              var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            throw ConfigError.malformed("agent.json is not a JSON object")
+        }
+        root.removeValue(forKey: "autonomous_agent")
+        do {
+            let out = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+            try out.write(to: url, options: .atomic)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configPath)
+        } catch {
+            throw ConfigError.writeFailed(error.localizedDescription)
+        }
+    }
+}

--- a/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
@@ -200,7 +200,27 @@ final class MioAgentEnroller: ObservableObject {
     }
 
     private func handleTermination(exitCode: Int32) {
-        detachPipeHandlers()
+        // Deterministically DRAIN any bytes the edge-triggered readability handlers didn't
+        // consume — especially the final error line on a fast-failing login. The per-chunk
+        // ingest Tasks and this termination Task both hop onto the main actor with NO ordering
+        // guarantee, so racing them intermittently lost mio-agent's real reason and showed a
+        // generic "exited N" instead. We detach the handlers, then synchronously read what's
+        // left and fold it into lastLine BEFORE building the error detail.
+        let outHandle = outPipe?.fileHandleForReading
+        let errHandle = errPipe?.fileHandleForReading
+        outHandle?.readabilityHandler = nil
+        errHandle?.readabilityHandler = nil
+        for handle in [outHandle, errHandle].compactMap({ $0 }) {
+            let rest = handle.readDataToEndOfFile()
+            if let tail = String(data: rest, encoding: .utf8), !tail.isEmpty {
+                for rawLine in tail.split(separator: "\n", omittingEmptySubsequences: true) {
+                    let line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !line.isEmpty { lastLine = String(line.prefix(240)) }
+                }
+            }
+        }
+        outPipe = nil
+        errPipe = nil
         process = nil
         if exitCode == 0 {
             phase = .succeeded

--- a/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentEnroller.swift
@@ -105,16 +105,37 @@ final class MioAgentEnroller: ObservableObject {
     /// - `onIntent` fires once the `mio://enroll/...` deeplink is parsed, so the
     ///   caller can refresh the dual QR to embed this exact intent.
     /// - Re-runnable: cancels any in-flight login first.
-    func startEnrollment(serverUrl: String, deviceName: String, onIntent: @escaping (MioEnrollIntent) -> Void) {
+    // Retry bookkeeping: npx is flaky when spawned from the GUI app's launchd env
+    // (exits 1 with no usable error, unreproducible from a shell), while the installed
+    // SEA binary is reliable. If an npx login fails WITHOUT producing an intent, we retry
+    // once with the binary (see handleTermination). These remember the in-flight params.
+    private var lastServerUrl: String?
+    private var lastDeviceName: String?
+    private var lastOnIntent: ((MioEnrollIntent) -> Void)?
+    private var lastLaunchKind: MioAgentLauncher.Launch.Kind?
+    private var triedBinaryFallback = false
+
+    func startEnrollment(serverUrl: String, deviceName: String, forceBinary: Bool = false, onIntent: @escaping (MioEnrollIntent) -> Void) {
         // Resolve npx-cached first, installed binary as fallback (#117). If neither
         // is available, fail with a clear message rather than silently no-op.
+        // `forceBinary` skips npx entirely (used by the post-failure retry).
         let launch: MioAgentLauncher.Launch
-        switch MioAgentLauncher.resolve() {
-        case .success(let l): launch = l
-        case .failure:
-            phase = .failed(L10n.agentEnrollErrNoLauncher)
-            return
+        if forceBinary, FileManager.default.isExecutableFile(atPath: MioAgentLauncher.installedBinaryPath) {
+            launch = MioAgentLauncher.Launch(kind: .binary, executablePath: MioAgentLauncher.installedBinaryPath, prefixArgs: [], toolchainDir: nil)
+        } else {
+            switch MioAgentLauncher.resolve() {
+            case .success(let l): launch = l
+            case .failure:
+                phase = .failed(L10n.agentEnrollErrNoLauncher)
+                return
+            }
         }
+        // Remember params so a failed npx attempt can retry on the binary.
+        lastServerUrl = serverUrl
+        lastDeviceName = deviceName
+        lastOnIntent = onIntent
+        lastLaunchKind = launch.kind
+        if !forceBinary { triedBinaryFallback = false }
         // Tear down any previous attempt cleanly.
         cancelEnrollment()
 
@@ -279,6 +300,19 @@ final class MioAgentEnroller: ObservableObject {
             phase = .succeeded
             Self.logger.info("mio-agent login succeeded — Keychain + agent.json written by the binary")
         } else {
+            // npx is flaky from the GUI app's launchd env (exits non-zero without ever
+            // printing the deeplink). If THIS attempt was npx, produced NO intent, and a
+            // reliable installed binary exists, retry once on the binary before failing.
+            if intent == nil,
+               lastLaunchKind == .npx,
+               !triedBinaryFallback,
+               FileManager.default.isExecutableFile(atPath: MioAgentLauncher.installedBinaryPath),
+               let s = lastServerUrl, let n = lastDeviceName, let cb = lastOnIntent {
+                triedBinaryFallback = true
+                phase = .idle
+                startEnrollment(serverUrl: s, deviceName: n, forceBinary: true, onIntent: cb)
+                return
+            }
             // Prefer the captured tail (login prints a human-readable error on
             // its last line for timeouts / 403 / network errors).
             let detail = lastLine.isEmpty ? L10n.agentEnrollErrExit(exitCode) : lastLine

--- a/ClaudeIsland/Services/Agent/MioAgentLauncher.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentLauncher.swift
@@ -1,0 +1,161 @@
+//
+//  MioAgentLauncher.swift
+//  ClaudeIsland
+//
+//  Task #117 — npx-cached daemon distribution.
+//
+//  The daemon (`@miomioos/mio-agent`) ships TWO equivalent launch shapes that run
+//  the SAME CLI dispatch (login / run / etc — see mio-agent src/cli/index.ts):
+//
+//    A. npx-cached (PREFERRED):  npx -y @miomioos/mio-agent@<ver> <subcmd>
+//       npm caches the package under ~/.npm/_npx so subsequent launches are offline-fast.
+//       No SHA-pinned binary download, no ad-hoc codesign step — npm owns integrity.
+//
+//    B. GitHub-Release SEA binary (FALLBACK):  ~/.mio/bin/mio-agent <subcmd>
+//       Used only when npx is unavailable. Installed/verified by MioAgentDistribution.
+//
+//  This type resolves which strategy is usable on THIS machine and returns a concrete
+//  (executableURL, prefixArgs) the caller prepends to a subcommand. It NEVER fabricates
+//  a path — every returned launcher is backed by a file that exists on disk.
+//
+//  PATH note: a GUI app launched from Finder inherits a minimal PATH
+//  (/usr/bin:/bin:/usr/sbin:/sbin), so `npx`/`node` from nvm/Homebrew are NOT on it.
+//  We therefore probe a fixed set of well-known install locations rather than relying
+//  on PATH resolution.
+//
+
+import Foundation
+
+enum MioAgentLauncher {
+
+    /// The npm package + pinned version launched via npx. Keep the version in lockstep
+    /// with MioAgentDistribution.pinnedVersion so both launch paths run the same release.
+    static let npmPackage = "@miomioos/mio-agent"
+    static var npmSpec: String { "\(npmPackage)@\(MioAgentDistribution.pinnedVersion)" }
+
+    /// Installed SEA-binary location (the MioAgentDistribution destination).
+    static var installedBinaryPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".mio/bin/mio-agent").path
+    }
+
+    // MARK: - Strategy
+
+    /// A concrete, ready-to-run launch recipe. `executablePath` and every entry in
+    /// `prefixArgs` is real; append the daemon subcommand (e.g. ["login", "--server", …]).
+    struct Launch: Equatable {
+        enum Kind: Equatable { case npx, binary }
+        let kind: Kind
+        /// Absolute path to the executable to spawn (npx wrapper, or the SEA binary).
+        let executablePath: String
+        /// Arguments that select the daemon BEFORE the subcommand.
+        /// - npx:    ["-y", "@miomioos/mio-agent@<ver>"]
+        /// - binary: []
+        let prefixArgs: [String]
+        /// Directory containing node/npx — added to the child PATH so npx can find node
+        /// even under the minimal Finder-launched PATH. Empty for the binary path.
+        let toolchainDir: String?
+
+        /// Full argv (executable + prefix + subcommand) for a given daemon subcommand.
+        func argv(_ subcommand: [String]) -> [String] {
+            [executablePath] + prefixArgs + subcommand
+        }
+    }
+
+    /// Why no launcher is available — surfaced to the user instead of failing silently.
+    enum Unavailable: Error, Equatable {
+        /// Neither npx nor an installed binary was found.
+        case nothingAvailable
+    }
+
+    // MARK: - Resolution
+
+    /// Resolve the best available launch strategy: npx-cached first, installed binary as
+    /// fallback. Returns `.failure(.nothingAvailable)` when neither exists so the caller
+    /// can degrade gracefully with a clear message (no silent no-op).
+    static func resolve() -> Result<Launch, Unavailable> {
+        if let npx = findNpx() {
+            return .success(Launch(
+                kind: .npx,
+                executablePath: npx.path,
+                prefixArgs: ["-y", npmSpec],
+                toolchainDir: npx.dir
+            ))
+        }
+        if FileManager.default.isExecutableFile(atPath: installedBinaryPath) {
+            return .success(Launch(
+                kind: .binary,
+                executablePath: installedBinaryPath,
+                prefixArgs: [],
+                toolchainDir: nil
+            ))
+        }
+        return .failure(.nothingAvailable)
+    }
+
+    /// True when npx is the resolved strategy. Used to decide whether the install/download
+    /// step is even needed (npx makes the GitHub-binary download optional).
+    static var npxAvailable: Bool { findNpx() != nil }
+
+    // MARK: - npx discovery
+
+    /// Locate a real `npx` executable from well-known install roots (Finder PATH is minimal).
+    /// Returns the npx path AND its containing bin dir (so node beside it is on the child PATH).
+    private static func findNpx() -> (path: String, dir: String)? {
+        let fm = FileManager.default
+        var candidates: [String] = [
+            "/opt/homebrew/bin/npx",   // Apple-silicon Homebrew
+            "/usr/local/bin/npx",      // Intel Homebrew / generic
+        ]
+
+        // nvm: ~/.nvm/versions/node/<ver>/bin/npx — pick the highest semver present.
+        let nvmRoot = fm.homeDirectoryForCurrentUser
+            .appendingPathComponent(".nvm/versions/node")
+        if let versions = try? fm.contentsOfDirectory(atPath: nvmRoot.path) {
+            let sorted = versions.sorted(by: semverDescending)
+            for v in sorted {
+                candidates.append(nvmRoot.appendingPathComponent("\(v)/bin/npx").path)
+            }
+        }
+
+        // fnm / Volta common locations.
+        let home = fm.homeDirectoryForCurrentUser.path
+        candidates.append("\(home)/.volta/bin/npx")
+
+        for path in candidates where fm.isExecutableFile(atPath: path) {
+            return (path, (path as NSString).deletingLastPathComponent)
+        }
+        return nil
+    }
+
+    /// Descending semver comparison for nvm version directory names like "v22.22.0".
+    private static func semverDescending(_ a: String, _ b: String) -> Bool {
+        func parts(_ s: String) -> [Int] {
+            s.trimmingCharacters(in: CharacterSet(charactersIn: "v"))
+                .split(separator: ".")
+                .map { Int($0.prefix(while: { $0.isNumber })) ?? 0 }
+        }
+        let pa = parts(a), pb = parts(b)
+        for i in 0..<max(pa.count, pb.count) {
+            let x = i < pa.count ? pa[i] : 0
+            let y = i < pb.count ? pb[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+
+    // MARK: - Child environment
+
+    /// Build a child-process environment that puts the node toolchain dir on PATH so
+    /// `npx` can spawn `node`. For the binary path this is a no-op passthrough.
+    static func childEnvironment(for launch: Launch) -> [String: String] {
+        var env = Foundation.ProcessInfo.processInfo.environment
+        if let dir = launch.toolchainDir {
+            let existing = env["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+            if !existing.split(separator: ":").contains(Substring(dir)) {
+                env["PATH"] = "\(dir):\(existing)"
+            }
+        }
+        return env
+    }
+}

--- a/ClaudeIsland/Services/Agent/MioAgentLauncher.swift
+++ b/ClaudeIsland/Services/Agent/MioAgentLauncher.swift
@@ -122,10 +122,40 @@ enum MioAgentLauncher {
         let home = fm.homeDirectoryForCurrentUser.path
         candidates.append("\(home)/.volta/bin/npx")
 
+        // Require a MODERN npx (npm ≥ 7). npm 6's npx mis-resolves
+        // `npx -y <pkg> <subcmd>`: instead of passing <subcmd> to the package's
+        // bin, it treats it as a standalone command — so `login` fell through to
+        // the system `/usr/bin/login` ("usage: login -f …") and `run` installed
+        // and ran the unrelated `runjs` package. A stale /usr/local/bin/npx from
+        // an old global npm 6 install otherwise wins over the user's modern
+        // (nvm/Homebrew) npx and silently breaks enrollment + the daemon.
         for path in candidates where fm.isExecutableFile(atPath: path) {
+            guard npxMajorVersion(path) >= 7 else { continue }
             return (path, (path as NSString).deletingLastPathComponent)
         }
         return nil
+    }
+
+    /// Major version reported by `<npx> --version` (which prints the npm
+    /// version, e.g. "10.8.2" or "6.14.11"), or 0 if it can't be determined.
+    /// Used to reject npm 6's broken npx (see `findNpx`).
+    private static func npxMajorVersion(_ path: String) -> Int {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: path)
+        p.arguments = ["--version"]
+        let pipe = Pipe()
+        p.standardOutput = pipe
+        p.standardError = FileHandle.nullDevice
+        do {
+            try p.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            p.waitUntilExit()
+            let out = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return out.split(separator: ".").first.flatMap { Int($0) } ?? 0
+        } catch {
+            return 0
+        }
     }
 
     /// Descending semver comparison for nvm version directory names like "v22.22.0".

--- a/ClaudeIsland/Services/Sync/ServerConnection.swift
+++ b/ClaudeIsland/Services/Sync/ServerConnection.swift
@@ -65,6 +65,22 @@ final class ServerConnection: ObservableObject {
     func authenticate() async throws {
         state = .authenticating
 
+        // Slock monitoring auth: PREFER the enrollment machine_token. Since Slice 7,
+        // POST /v1/auth hard-requires a user_sess_ that this machine-scoped daemon
+        // does not have. After workspace enrollment we DO hold a machine_token (in
+        // the mio-agent Keychain item), and POST /v1/auth/machine exchanges it for a
+        // monitoring device JWT + shortCode — so one QR scan sets up both universes.
+        // Fall back to the legacy device-keypair flow only when no machine_token is
+        // present (Mac not yet enrolled).
+        if let machineToken = Self.readMachineToken() {
+            do {
+                try await authenticateWithMachineToken(machineToken)
+                return
+            } catch {
+                Self.logger.error("machine_token auth failed: \(error.localizedDescription, privacy: .public) — falling back to keypair")
+            }
+        }
+
         let _ = try keyManager.getOrCreateIdentityKey()
 
         let challenge = UUID().uuidString
@@ -100,6 +116,72 @@ final class ServerConnection: ObservableObject {
         } else {
             state = .error("No token received")
         }
+    }
+
+    /// Read the enrollment machine_token from the mio-agent Keychain item.
+    /// mio-agent stores it via `security add-generic-password` with NO app ACL
+    /// (`-T`), so the only trusted app is `/usr/bin/security` itself — any
+    /// same-user process reading through `security find-generic-password`
+    /// succeeds WITHOUT a Keychain prompt. The token never touches logs.
+    private static func readMachineToken() -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        task.arguments = ["find-generic-password",
+                          "-s", "io.miomioos.mio-agent",
+                          "-a", "machine_token",
+                          "-w"]
+        let out = Pipe()
+        task.standardOutput = out
+        task.standardError = Pipe()
+        do {
+            try task.run()
+            task.waitUntilExit()
+            guard task.terminationStatus == 0 else { return nil }
+            let data = out.fileHandleForReading.readDataToEndOfFile()
+            let tok = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return (tok?.isEmpty == false) ? tok : nil
+        } catch {
+            return nil
+        }
+    }
+
+    /// Exchange a machine_token for a monitoring device JWT + shortCode via
+    /// POST /v1/auth/machine. On success sets token / deviceId / shortCode and
+    /// persists the JWT to the Keychain (same slot the keypair flow uses).
+    private func authenticateWithMachineToken(_ machineToken: String) async throws {
+        let url = URL(string: "\(serverUrl)/v1/auth/machine")!
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("Bearer \(machineToken)", forHTTPHeaderField: "Authorization")
+        req.httpBody = Data("{}".utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse else {
+            throw NSError(domain: "ServerConnection", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "no http response"])
+        }
+        guard http.statusCode == 200 else {
+            throw NSError(domain: "ServerConnection", code: http.statusCode,
+                          userInfo: [NSLocalizedDescriptionKey: "machine auth http \(http.statusCode)"])
+        }
+
+        struct MachineAuthResponse: Decodable {
+            let token: String?
+            let deviceId: String?
+            let shortCode: String?
+        }
+        let parsed = try JSONDecoder().decode(MachineAuthResponse.self, from: data)
+        guard let t = parsed.token else {
+            throw NSError(domain: "ServerConnection", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "machine auth returned no token"])
+        }
+        self.token = t
+        self.deviceId = parsed.deviceId
+        if let sc = parsed.shortCode { self.shortCode = sc }
+        try keyManager.storeToken(t, forServer: serverUrl)
+        Self.logger.info("Authenticated via machine_token with \(self.serverUrl), shortCode=\(self.shortCode ?? "nil", privacy: .public)")
     }
 
     // MARK: - Socket.io Connection

--- a/ClaudeIsland/Services/Sync/ServerConnection.swift
+++ b/ClaudeIsland/Services/Sync/ServerConnection.swift
@@ -65,57 +65,26 @@ final class ServerConnection: ObservableObject {
     func authenticate() async throws {
         state = .authenticating
 
-        // Slock monitoring auth: PREFER the enrollment machine_token. Since Slice 7,
-        // POST /v1/auth hard-requires a user_sess_ that this machine-scoped daemon
-        // does not have. After workspace enrollment we DO hold a machine_token (in
-        // the mio-agent Keychain item), and POST /v1/auth/machine exchanges it for a
-        // monitoring device JWT + shortCode — so one QR scan sets up both universes.
-        // Fall back to the legacy device-keypair flow only when no machine_token is
-        // present (Mac not yet enrolled).
-        if let machineToken = Self.readMachineToken() {
-            do {
-                try await authenticateWithMachineToken(machineToken)
-                return
-            } catch {
-                Self.logger.error("machine_token auth failed: \(error.localizedDescription, privacy: .public) — falling back to keypair")
-            }
+        // Account-only identity contract (2026-06-03): the Mac authenticates and
+        // pushes as an OWNERLESS computer. Its only monitoring identity is the
+        // enrollment machine_token (in the mio-agent Keychain item); POST
+        // /v1/auth/machine exchanges it for a monitoring device JWT + shortCode.
+        // The returned computer carries NO owner — ownership lives solely in the
+        // server-side AccountComputerLink, established later by a phone scan — so
+        // this code must not expect or rely on any per-account device ownership.
+        //
+        // The legacy device-keypair /v1/auth flow is gone: under the contract
+        // /v1/auth hard-requires a user_sess_ this machine-scoped daemon never
+        // holds, and it bound Device.userId to a single owner — exactly the
+        // per-account ownership the refactor retires. A Mac with no machine_token
+        // is simply not enrolled and cannot do ownerless monitoring auth.
+        guard let machineToken = Self.readMachineToken() else {
+            state = .error("Not enrolled (no machine_token); cannot authenticate as an ownerless computer")
+            throw NSError(domain: "ServerConnection", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "no machine_token: Mac not enrolled"])
         }
 
-        let _ = try keyManager.getOrCreateIdentityKey()
-
-        let challenge = UUID().uuidString
-        let challengeData = Data(challenge.utf8)
-        let signature = try keyManager.sign(challengeData)
-        let publicKey = try keyManager.publicKeyBase64()
-
-        let request = AuthRequest(
-            publicKey: publicKey,
-            challenge: challengeData.base64EncodedString(),
-            signature: signature.base64EncodedString()
-        )
-
-        let url = URL(string: "\(serverUrl)/v1/auth")!
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.httpBody = try JSONEncoder().encode(request)
-
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
-
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            state = .error("Auth failed")
-            return
-        }
-
-        let authResponse = try JSONDecoder().decode(AuthResponse.self, from: data)
-        if let t = authResponse.token {
-            self.token = t
-            self.deviceId = authResponse.deviceId
-            try keyManager.storeToken(t, forServer: serverUrl)
-            Self.logger.info("Authenticated with \(self.serverUrl)")
-        } else {
-            state = .error("No token received")
-        }
+        try await authenticateWithMachineToken(machineToken)
     }
 
     /// Read the enrollment machine_token from the mio-agent Keychain item.
@@ -148,7 +117,14 @@ final class ServerConnection: ObservableObject {
 
     /// Exchange a machine_token for a monitoring device JWT + shortCode via
     /// POST /v1/auth/machine. On success sets token / deviceId / shortCode and
-    /// persists the JWT to the Keychain (same slot the keypair flow uses).
+    /// persists the JWT to the Keychain.
+    ///
+    /// Account-only identity contract (§2.6): the response shape is unchanged —
+    /// `{ success, token, deviceId, shortCode, expiresInDays }` — but the computer
+    /// is now OWNERLESS. The device JWT is a non-identity push/transport handle
+    /// only (its `userId` claim may be empty), so we read just token / deviceId /
+    /// shortCode and make NO assumption that an owner came back. The shortCode is
+    /// the monitor_code the dual QR embeds (carried via SyncManager.shortCode).
     private func authenticateWithMachineToken(_ machineToken: String) async throws {
         let url = URL(string: "\(serverUrl)/v1/auth/machine")!
         var req = URLRequest(url: url)

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -668,14 +668,6 @@ struct AgentSettingsTab: View {
             snap.lastDiagnostic = L10n.agentDiagInstalling
         }
 
-        guard let srcPath = Bundle.main.path(forResource: "mio-agent", ofType: nil) else {
-            await MainActor.run {
-                snap.phase = .error
-                snap.lastDiagnostic = L10n.agentDiagBundleNotFound
-            }
-            return
-        }
-
         let mioDir = (binaryPath as NSString).deletingLastPathComponent
         let launchAgentsDir = (plistPath as NSString).deletingLastPathComponent
 
@@ -683,13 +675,22 @@ struct AgentSettingsTab: View {
             try FileManager.default.createDirectory(atPath: mioDir, withIntermediateDirectories: true)
             try FileManager.default.createDirectory(atPath: launchAgentsDir, withIntermediateDirectories: true)
 
-            if FileManager.default.fileExists(atPath: binaryPath) {
-                try FileManager.default.removeItem(atPath: binaryPath)
-            }
-            try FileManager.default.copyItem(atPath: srcPath, toPath: binaryPath)
-            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryPath)
+            // Download, verify (SHA-256), extract, and atomically install the daemon binary
+            // from the GitHub Release artifact. This replaces the old bundle-lookup approach
+            // (Bundle.main.path forResource:"mio-agent") — the Resources phase is intentionally
+            // empty; the binary is always fetched fresh from the pinned release tag (#121).
+            //
+            // No-overwrite-on-fail: MioAgentDistribution only writes to binaryPath after all
+            // verification passes; any earlier failure leaves the existing binary intact.
+            try await MioAgentDistribution.downloadAndInstall(
+                to: binaryPath,
+                onProgress: { [self] msg in
+                    Task { @MainActor in snap.lastDiagnostic = msg }
+                }
+            )
 
             // Ad-hoc codesign required on Apple Silicon for launchd/Keychain access
+            await MainActor.run { snap.lastDiagnostic = "Signing binary..." }
             await shellRun("/usr/bin/codesign", args: ["--sign", "-", "--force", binaryPath])
 
             let plistContent = launchAgentPlist()

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -410,8 +410,10 @@ struct AgentSettingsTab: View {
             actionInProgress = true
             lastActionMessage = L10n.isChinese ? "正在启动…" : "Starting…"
         }
+        // After a `bootout` the job is unloaded; must `bootstrap` again to load it.
+        // `kickstart` only works when the job is already loaded — not safe after Stop.
         let uid = "\(getuid())"
-        await shellRun("/bin/launchctl", args: ["kickstart", "-k", "user/\(uid)/\(launchLabel)"])
+        await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
         await refreshStatus()
         await MainActor.run {
             lastActionMessage = processRunning
@@ -426,9 +428,12 @@ struct AgentSettingsTab: View {
             actionInProgress = true
             lastActionMessage = L10n.isChinese ? "正在停止…" : "Stopping…"
         }
+        // Use `bootout` to fully unload the job. `kill SIGTERM` does NOT stop a
+        // KeepAlive job — launchd immediately restarts it after the process exits.
+        // Phase 2 NOTE: this is not drain-safe (IPC drain / irreversible action
+        // wait is not implemented yet). Full drain-safe Stop = Phase 2.
         let uid = "\(getuid())"
-        await shellRun("/bin/launchctl", args: ["kill", "SIGTERM", "user/\(uid)/\(launchLabel)"])
-        try? await Task.sleep(nanoseconds: 1_200_000_000)  // give process time to drain
+        await shellRun("/bin/launchctl", args: ["bootout", "user/\(uid)/\(launchLabel)"])
         await refreshStatus()
         await MainActor.run {
             lastActionMessage = processRunning
@@ -476,6 +481,8 @@ struct AgentSettingsTab: View {
             <true/>
             <key>KeepAlive</key>
             <true/>
+            <key>ExitTimeOut</key>
+            <integer>15</integer>
             <key>StandardOutPath</key>
             <string>\(home)/.mio/agent.log</string>
             <key>StandardErrorPath</key>

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -410,10 +410,18 @@ struct AgentSettingsTab: View {
             actionInProgress = true
             lastActionMessage = L10n.isChinese ? "正在启动…" : "Starting…"
         }
-        // After a `bootout` the job is unloaded; must `bootstrap` again to load it.
-        // `kickstart` only works when the job is already loaded — not safe after Stop.
         let uid = "\(getuid())"
-        await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
+        // Decide bootstrap vs kickstart based on whether the job is already loaded.
+        //   - Loaded (job in launchd domain, process may be stopped/crashed) → `kickstart -k`
+        //     to restart without re-registering the plist.
+        //   - Not loaded (after bootout or first install) → `bootstrap` to register the plist.
+        // This handles the edge case where the job is loaded but the process crashed:
+        // `bootstrap` would fail with "service already loaded"; `kickstart -k` restarts it.
+        if await isJobLoaded() {
+            await shellRun("/bin/launchctl", args: ["kickstart", "-k", "user/\(uid)/\(launchLabel)"])
+        } else {
+            await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
+        }
         await refreshStatus()
         await MainActor.run {
             lastActionMessage = processRunning
@@ -428,10 +436,14 @@ struct AgentSettingsTab: View {
             actionInProgress = true
             lastActionMessage = L10n.isChinese ? "正在停止…" : "Stopping…"
         }
+        // Phase 2 IPC drain hook — currently a no-op.
+        // Phase 2: replace with real IPC drain — send drain request via agent.sock,
+        // wait for irreversible in-flight actions to reach transmission_complete or
+        // needs_human before proceeding, with a hard deadline (spec: 8s / ExitTimeOut=15s).
+        await requestDrain(deadlineMs: 8_000)
+
         // Use `bootout` to fully unload the job. `kill SIGTERM` does NOT stop a
         // KeepAlive job — launchd immediately restarts it after the process exits.
-        // Phase 2 NOTE: this is not drain-safe (IPC drain / irreversible action
-        // wait is not implemented yet). Full drain-safe Stop = Phase 2.
         let uid = "\(getuid())"
         await shellRun("/bin/launchctl", args: ["bootout", "user/\(uid)/\(launchLabel)"])
         await refreshStatus()
@@ -441,6 +453,27 @@ struct AgentSettingsTab: View {
                 : (L10n.isChinese ? "已停止" : "Stopped")
             actionInProgress = false
         }
+    }
+
+    /// Check whether the LaunchAgent job is currently registered in the launchd user domain.
+    /// Uses the domain-aware form `launchctl print user/<uid>/<label>` (exit 0 = job loaded)
+    /// rather than legacy `launchctl list <label>`, consistent with the bootstrap/bootout/kickstart
+    /// domain specifiers used elsewhere in this file.
+    private func isJobLoaded() async -> Bool {
+        let uid = "\(getuid())"
+        return await shellCheck("launchctl", args: ["print", "user/\(uid)/\(launchLabel)"])
+    }
+
+    /// IPC drain stub — no-op in Phase 1.
+    ///
+    /// Phase 2 implementation: open a Unix socket connection to `socketPath` (agent.sock),
+    /// send a drain request, and await acknowledgment that no irreversible actions are in-flight,
+    /// or until `deadlineMs` elapses (whichever comes first). On deadline, proceed with bootout
+    /// anyway — the agent's ExitTimeOut=15s provides a final safety window.
+    private func requestDrain(deadlineMs: Int) async {
+        // Phase 1: no IPC socket exists yet. Return immediately.
+        // Phase 2: replace this body with real socket drain logic.
+        _ = deadlineMs  // suppress unused-warning; parameter intentional for Phase 2 signature
     }
 
     @discardableResult

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -145,7 +145,7 @@ struct AgentSettingsTab: View {
         .appendingPathComponent(".mio/agent.log").path
     private let mioDir = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".mio")
-    private let healthURL = URL(string: "http://127.0.0.1:7878")!
+    private let healthURL = URL(string: "http://127.0.0.1:7878/health")!
     private let launchLabel = "io.miomioos.mio-agent"
 
     var body: some View {
@@ -587,7 +587,8 @@ struct AgentSettingsTab: View {
         let procRunning = await shellCheck("/usr/bin/pgrep", args: ["-x", "mio-agent"])
 
         // Health endpoint (only meaningful when process is running)
-        let healthy = procRunning ? await pingHealth() : false
+        let healthResult = procRunning ? await pingHealth() : (reachable: false, error: nil as String?)
+        let healthy = healthResult.reachable
 
         await MainActor.run {
             snap.binaryExists = binExists
@@ -615,18 +616,30 @@ struct AgentSettingsTab: View {
                 snap.phase = .runningHealthy
             } else {
                 snap.phase = .runningUnhealthy
+                // Surface the actual probe failure so the user can see why health is red.
+                if let healthError = healthResult.error {
+                    snap.lastDiagnostic = healthError
+                }
             }
         }
     }
 
-    private func pingHealth() async -> Bool {
+    /// Probe the daemon health endpoint. Returns reachable=true on HTTP 200.
+    /// On any failure (non-200 or network error) returns reachable=false with a human-readable
+    /// error string so the UI can surface the real reason instead of a generic "unhealthy" label.
+    private func pingHealth() async -> (reachable: Bool, error: String?) {
         do {
             var req = URLRequest(url: healthURL)
-            req.timeoutInterval = 0.5
+            req.timeoutInterval = 2.0
             let (_, resp) = try await URLSession.shared.data(for: req)
-            return (resp as? HTTPURLResponse)?.statusCode == 200
+            let status = (resp as? HTTPURLResponse)?.statusCode ?? 0
+            if status == 200 {
+                return (true, nil)
+            } else {
+                return (false, "Health probe HTTP \(status) — expected 200")
+            }
         } catch {
-            return false
+            return (false, "Health probe: \(error.localizedDescription)")
         }
     }
 

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -258,6 +258,13 @@ struct AgentSettingsTab: View {
             )
             Divider().opacity(0.3)
             lifecycleRow(
+                icon: "gearshape.fill",
+                title: "Config",
+                path: configPath,
+                state: snap.configExists ? ("Present", Theme.success) : ("Missing — run mio-agent login", Theme.warning)
+            )
+            Divider().opacity(0.3)
+            lifecycleRow(
                 icon: "gear",
                 title: "LaunchAgent",
                 path: launchLabel,
@@ -351,9 +358,10 @@ struct AgentSettingsTab: View {
             // Setup required hint: shown when agent.json is missing
             if snap.phase == .notConfigured {
                 VStack(alignment: .leading, spacing: 5) {
-                    Text("Run this command in Terminal to configure the agent:")
+                    Text("Run this command in Terminal, then enter your server URL (e.g. https://mio.wdao.chat) when prompted:")
                         .font(.system(size: 10))
                         .foregroundColor(Theme.subtle)
+                        .fixedSize(horizontal: false, vertical: true)
                     HStack(spacing: 6) {
                         Text("mio-agent login")
                             .font(.system(size: 11, weight: .medium))

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -2,15 +2,15 @@
 //  AgentSettingsTab.swift
 //  ClaudeIsland
 //
-//  Mio Agent settings tab — status monitoring, install/start/stop controls,
-//  and unavailable-capability rows for features pending Phase 2 IPC.
+//  Mio Agent settings tab — Phase 2 state design implementation.
 //
-//  Phase 1 scope (task #70):
-//  - Status card: binary presence, process health, health endpoint ping
-//  - Controls card: Install / Start / Stop buttons via launchctl
-//  - Unavailable rows: Action execution, Workroom, Log streaming, SMAppService upgrade
+//  Phase 1 scope (#70/#74): Install/Start/Stop via launchctl + basic status probe.
+//  Phase 2 scope (#93, spec #90): Full AgentLifecyclePhase state model, LaunchAgent
+//    loaded detection, lifecycle detail rows, Logs card, honest Phase 1 stop copy.
 //
-//  Phase 2 (tracked separately): IPC socket, real-time status, Workroom binding.
+//  State model: docs/productization/agent-tab-phase2-state-design.md
+//
+//  Phase 2 stubs (IPC drain, real-time status, log streaming): marked TODO(Phase2).
 //
 
 import AppKit
@@ -18,246 +18,490 @@ import Foundation
 import ServiceManagement
 import SwiftUI
 
-// MARK: - Agent Status
+// MARK: - AgentLifecyclePhase
 
-private enum AgentStatus: Equatable {
-    case checking
-    case notInstalled   // ~/.mio/bin/mio-agent doesn't exist
-    case stopped        // binary present, not running
-    case running        // process alive + health endpoint reachable
-    case unhealthy      // process found but health endpoint timeout/error
+/// Full state model per #90 spec §3.
+///
+/// Distinguishes binary presence, LaunchAgent registration, process running,
+/// health endpoint availability, and transient busy states.
+enum AgentLifecyclePhase: Equatable {
+    case checking           // initial probe in progress
+    case notInstalled       // ~/.mio/bin/mio-agent missing
+    case installedUnloaded  // binary present, launchd job not loaded
+    case loadedStopped      // job loaded, process not running
+    case starting           // install/start command in progress
+    case runningHealthy     // process running + health endpoint 200
+    case runningUnhealthy   // process running, health endpoint unreachable
+    case draining           // TODO(Phase2): IPC drain in progress
+    case stopping           // bootout in progress
+    case error              // controlled diagnostic — see snap.lastDiagnostic
+    case unknown            // probe failed or data stale
+
+    // MARK: Display
 
     var dotColor: Color {
         switch self {
-        case .checking:     return Theme.neutralDot
-        case .notInstalled: return Theme.neutralDot
-        case .stopped:      return Theme.warning
-        case .running:      return Theme.success
-        case .unhealthy:    return Theme.error
+        case .checking, .unknown:                return Theme.neutralDot
+        case .notInstalled:                      return Theme.neutralDot
+        case .installedUnloaded, .loadedStopped: return Theme.warning
+        case .starting, .stopping, .draining:    return .blue
+        case .runningHealthy:                    return Theme.success
+        case .runningUnhealthy, .error:          return Theme.error
         }
     }
 
-    var label: String {
+    var showSpinner: Bool {
         switch self {
-        case .checking:     return "检测中…"
-        case .notInstalled: return "未安装"
-        case .stopped:      return "已停止"
-        case .running:      return "运行中"
-        case .unhealthy:    return "进程存在但健康检测失败"
+        case .checking, .starting, .stopping, .draining: return true
+        default: return false
         }
+    }
+
+    var primaryLabel: String {
+        switch self {
+        case .checking:          return "Checking…"
+        case .notInstalled:      return "Not installed"
+        case .installedUnloaded: return "Installed · stopped"
+        case .loadedStopped:     return "Loaded · not running"
+        case .starting:          return "Starting…"
+        case .runningHealthy:    return "Running"
+        case .runningUnhealthy:  return "Running · health check failed"
+        case .draining:          return "Stopping safely…"
+        case .stopping:          return "Stopping…"
+        case .error:             return "Action failed"
+        case .unknown:           return "Status unknown"
+        }
+    }
+
+    var descriptionText: String {
+        switch self {
+        case .checking:
+            return "Probing agent status…"
+        case .notInstalled:
+            return "Install the bundled mio-agent before starting local action execution."
+        case .installedUnloaded:
+            return "The LaunchAgent is not running. Start it to prepare local action execution."
+        case .loadedStopped:
+            return "The job is loaded but the process is not running. Start will kickstart the job."
+        case .starting:
+            return "Wait; controls are disabled while the agent starts."
+        case .runningHealthy:
+            return "mio-agent is available on this Mac."
+        case .runningUnhealthy:
+            return "The process exists, but the local health endpoint did not respond."
+        case .draining:
+            return "Waiting for in-flight actions to reach a safe stopping point."
+        case .stopping:
+            return "The agent will be unloaded from launchd. Drain-safe stop is coming in Phase 2."
+        case .error:
+            return ""   // diagnostic carried in snap.lastDiagnostic
+        case .unknown:
+            return "Could not determine agent status. Refresh to try again."
+        }
+    }
+
+    /// True while a launchctl/install command is in flight.
+    var isBusy: Bool {
+        switch self {
+        case .checking, .starting, .stopping, .draining: return true
+        default: return false
+        }
+    }
+}
+
+// MARK: - AgentLifecycleSnapshot
+
+/// Single view model passed through the UI.
+struct AgentLifecycleSnapshot {
+    var binaryExists: Bool = false
+    var launchAgentLoaded: Bool? = nil  // nil = probe not run yet
+    var processRunning: Bool = false
+    var healthReachable: Bool = false
+    var socketExists: Bool? = nil       // Phase 2: ~/.mio/agent.sock
+    var logFileExists: Bool = false
+    var phase: AgentLifecyclePhase = .checking
+    var lastCheckedAt: Date? = nil
+    var lastDiagnostic: String? = nil   // error/diagnostic copy (controlled)
+
+    var isBusy: Bool { phase.isBusy }
+
+    var lastCheckedLabel: String {
+        guard let date = lastCheckedAt else { return "" }
+        let fmt = DateFormatter()
+        fmt.dateFormat = "HH:mm"
+        return "Last checked \(fmt.string(from: date))"
     }
 }
 
 // MARK: - AgentSettingsTab
 
 struct AgentSettingsTab: View {
-    @State private var status: AgentStatus = .checking
-    @State private var binaryExists = false
-    @State private var processRunning = false
-    @State private var healthReachable = false
-    @State private var actionInProgress = false
-    @State private var lastActionMessage: String? = nil
+    @State private var snap = AgentLifecycleSnapshot()
 
-    // Known paths — Phase 2 may make these configurable
+    // Known paths
     private let binaryPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".mio/bin/mio-agent").path
     private let plistPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/LaunchAgents/io.miomioos.mio-agent.plist").path
     private let socketPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".mio/agent.sock").path
+    private let logPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".mio/agent.log").path
     private let healthURL = URL(string: "http://127.0.0.1:7878")!
     private let launchLabel = "io.miomioos.mio-agent"
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
-            // Header description
-            Text(L10n.isChinese
-                 ? "Mio Agent 是在本机后台运行的守护进程，负责与 AI runtime 通信、执行 action 并上报结果。"
-                 : "Mio Agent is a background daemon that communicates with AI runtimes, fires actions, and reports results to MioServer.")
+            // Description
+            Text("Mio Agent is a background daemon that communicates with AI runtimes, fires actions, and reports results to MioServer.")
                 .font(.system(size: 11))
                 .foregroundColor(Theme.subtle)
 
-            // MARK: Status card
-            SectionLabel(L10n.isChinese ? "状态" : "Status")
-            SettingsCard {
-                statusRow(
-                    icon: "cpu",
-                    title: L10n.isChinese ? "守护进程二进制" : "Daemon binary",
-                    ok: binaryExists ? true : false,
-                    detail: binaryExists ? binaryPath : (L10n.isChinese ? "未找到 — 请先安装" : "Not found — install first")
-                )
-                statusRow(
-                    icon: "bolt.fill",
-                    title: L10n.isChinese ? "进程状态" : "Process",
-                    ok: processRunning ? true : (binaryExists ? false : nil),
-                    detail: processRunning
-                        ? (L10n.isChinese ? "运行中" : "Running")
-                        : (L10n.isChinese ? "未运行" : "Not running")
-                )
-                statusRow(
-                    icon: "heart.fill",
-                    title: L10n.isChinese ? "健康端点" : "Health endpoint",
-                    ok: healthReachable ? true : (processRunning ? false : nil),
-                    detail: healthReachable
-                        ? "127.0.0.1:7878 ✓"
-                        : (L10n.isChinese ? "不可达" : "Unreachable")
-                )
-            }
+            // MARK: Overall status card
+            overallStatusCard
 
-            // MARK: Controls card
-            SectionLabel(L10n.isChinese ? "控制" : "Controls")
-            SettingsCard {
-                HStack(spacing: 8) {
-                    // Install button — only relevant when binary is absent
-                    controlButton(
-                        label: L10n.isChinese ? "安装" : "Install",
-                        icon: "arrow.down.circle.fill",
-                        enabled: !binaryExists && !actionInProgress
-                    ) { await installAgent() }
+            // MARK: Lifecycle detail rows
+            SectionLabel("Lifecycle")
+            lifecycleDetailRows
 
-                    // Start / Stop toggle
-                    if processRunning {
-                        controlButton(
-                            label: L10n.isChinese ? "停止" : "Stop",
-                            icon: "stop.fill",
-                            enabled: binaryExists && !actionInProgress,
-                            destructive: true
-                        ) { await stopAgent() }
-                    } else {
-                        controlButton(
-                            label: L10n.isChinese ? "启动" : "Start",
-                            icon: "play.fill",
-                            enabled: binaryExists && !actionInProgress
-                        ) { await startAgent() }
-                    }
+            // MARK: Controls
+            SectionLabel("Controls")
+            controlsCard
 
-                    // Refresh status
-                    Button {
-                        Task { await refreshStatus() }
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundColor(Theme.subtle)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(actionInProgress)
-                }
+            // MARK: Logs card
+            SectionLabel("Logs")
+            logsCard
 
-                if let msg = lastActionMessage {
-                    Text(msg)
-                        .font(.system(size: 10))
-                        .foregroundColor(Theme.subtle)
-                        .padding(.top, 2)
-                }
-            }
-
-            // MARK: Unavailable capabilities
-            SectionLabel(L10n.isChinese ? "能力（待实现）" : "Capabilities (coming soon)")
-            SettingsListCard {
-                unavailableRow(
-                    icon: "bolt.horizontal.fill",
-                    label: L10n.isChinese ? "Action 执行" : "Action execution",
-                    sublabel: L10n.isChinese
-                        ? "需要 Phase 2 IPC — runtime adapter 对接"
-                        : "Requires Phase 2 IPC — runtime adapter integration"
-                )
-                unavailableRow(
-                    icon: "rectangle.3.group.fill",
-                    label: L10n.isChinese ? "Workroom 绑定" : "Workroom binding",
-                    sublabel: L10n.isChinese
-                        ? "需要 MioServer 人工 auth cursor"
-                        : "Requires MioServer human-auth cursor"
-                )
-                unavailableRow(
-                    icon: "list.bullet.rectangle.fill",
-                    label: L10n.isChinese ? "日志 streaming" : "Log streaming",
-                    sublabel: L10n.isChinese
-                        ? "需要 IPC socket 接入"
-                        : "Requires IPC socket integration"
-                )
-                unavailableRow(
-                    icon: "arrow.up.circle.fill",
-                    label: L10n.isChinese ? "自动升级（SMAppService）" : "Auto-upgrade (SMAppService)",
-                    sublabel: L10n.isChinese
-                        ? "需要 upgrade.ts re-register 机制"
-                        : "Requires upgrade.ts re-register mechanism",
-                    isLast: true
-                )
-            }
+            // MARK: Upcoming capabilities
+            SectionLabel("Capabilities (coming soon)")
+            upcomingCapabilitiesCard
         }
         .task { await refreshStatus() }
     }
 
-    // MARK: - Status row (reuse CmuxConnectionTab pattern)
+    // MARK: - Overall status card
+
+    private var overallStatusCard: some View {
+        SettingsCard {
+            HStack(alignment: .top, spacing: 12) {
+                // Dot / spinner
+                if snap.phase.showSpinner {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .frame(width: 10, height: 10)
+                        .padding(.top, 2)
+                } else {
+                    Circle()
+                        .fill(snap.phase.dotColor)
+                        .frame(width: 10, height: 10)
+                        .padding(.top, 2)
+                }
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(snap.phase.primaryLabel)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(Theme.detailText)
+
+                    let desc = snap.phase == .error
+                        ? (snap.lastDiagnostic ?? "An error occurred.")
+                        : snap.phase.descriptionText
+                    if !desc.isEmpty {
+                        Text(desc)
+                            .font(.system(size: 11))
+                            .foregroundColor(Theme.subtle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                // Last checked + refresh
+                VStack(alignment: .trailing, spacing: 4) {
+                    if !snap.lastCheckedLabel.isEmpty {
+                        Text(snap.lastCheckedLabel)
+                            .font(.system(size: 10))
+                            .foregroundColor(Theme.subtle)
+                    }
+                    Button {
+                        Task { await refreshStatus() }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 11))
+                            .foregroundColor(snap.isBusy ? Theme.subtle.opacity(0.5) : Theme.subtle)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(snap.isBusy)
+                }
+            }
+        }
+    }
+
+    // MARK: - Lifecycle detail rows
+
+    private var lifecycleDetailRows: some View {
+        SettingsListCard {
+            lifecycleRow(
+                icon: "doc.fill",
+                title: "Binary",
+                path: binaryPath,
+                state: snap.binaryExists ? ("Installed", Theme.success) : ("Missing", Theme.error)
+            )
+            Divider().opacity(0.3)
+            lifecycleRow(
+                icon: "gear",
+                title: "LaunchAgent",
+                path: launchLabel,
+                state: {
+                    switch snap.launchAgentLoaded {
+                    case .some(true):  return ("Loaded", Theme.success)
+                    case .some(false): return ("Unloaded", Theme.warning)
+                    case .none:        return ("Unknown", Theme.neutralDot)
+                    }
+                }()
+            )
+            Divider().opacity(0.3)
+            lifecycleRow(
+                icon: "bolt.fill",
+                title: "Process",
+                path: "mio-agent",
+                state: snap.processRunning
+                    ? ("Running", Theme.success)
+                    : ("Stopped", Theme.warning)
+            )
+            Divider().opacity(0.3)
+            lifecycleRow(
+                icon: "heart.fill",
+                title: "Health",
+                path: "127.0.0.1:7878",
+                state: snap.healthReachable
+                    ? ("OK", Theme.success)
+                    : (snap.processRunning ? "Failed" : "Unavailable", snap.processRunning ? Theme.error : Theme.neutralDot)
+            )
+            Divider().opacity(0.3)
+            lifecycleRow(
+                icon: "point.3.connected.trianglepath.dotted",
+                title: "Socket",
+                path: "~/.mio/agent.sock",
+                state: ("Pending Phase 2", Theme.neutralDot),
+                isLast: true
+            )
+        }
+    }
+
+    // MARK: - Controls card
+
+    private var controlsCard: some View {
+        SettingsCard {
+            // Button row — visibility driven by phase
+            HStack(spacing: 8) {
+                // Install: shown when not installed
+                if !snap.binaryExists {
+                    accentButton(
+                        label: "Install",
+                        icon: "arrow.down.circle.fill",
+                        enabled: !snap.isBusy
+                    ) { await installAgent() }
+                }
+
+                // Start: shown when installed + not running
+                if snap.binaryExists && !snap.processRunning
+                    && snap.phase != .starting && snap.phase != .stopping {
+                    accentButton(
+                        label: "Start",
+                        icon: "play.fill",
+                        enabled: !snap.isBusy
+                    ) { await startAgent() }
+                }
+
+                // Stop: shown when running or job loaded
+                if snap.processRunning || snap.launchAgentLoaded == true {
+                    if snap.phase != .starting && snap.phase != .stopping {
+                        outlineButton(
+                            label: "Stop",
+                            icon: "stop.fill",
+                            enabled: !snap.isBusy
+                        ) { await stopAgent() }
+                    }
+                }
+
+                // Refresh
+                Button {
+                    Task { await refreshStatus() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(snap.isBusy ? Theme.subtle.opacity(0.5) : Theme.subtle)
+                }
+                .buttonStyle(.plain)
+                .disabled(snap.isBusy)
+
+                Spacer()
+            }
+
+            // Last action message / diagnostic
+            if let diag = snap.lastDiagnostic {
+                Text(diag)
+                    .font(.system(size: 10))
+                    .foregroundColor(snap.phase == .error ? Theme.error : Theme.subtle)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 2)
+            }
+        }
+    }
+
+    // MARK: - Logs card
+
+    private var logsCard: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Use logs for install/start/stop diagnostics. Sensitive values are not expected here.")
+                    .font(.system(size: 10))
+                    .foregroundColor(Theme.subtle)
+
+                HStack(spacing: 8) {
+                    accentButton(label: "Open log file", icon: "doc.text", enabled: snap.binaryExists) {
+                        openLogFile()
+                    }
+                    outlineButton(label: "Copy last 100 lines", icon: "doc.on.clipboard", enabled: snap.logFileExists) {
+                        copyLastLinesOfLog(count: 100)
+                    }
+                }
+
+                if !snap.logFileExists {
+                    Text("No agent log yet. Start the agent to create ~/.mio/agent.log.")
+                        .font(.system(size: 10))
+                        .foregroundColor(Theme.subtle.opacity(0.7))
+                        .padding(.top, 2)
+                }
+            }
+        }
+    }
+
+    // MARK: - Upcoming capabilities card
+
+    private var upcomingCapabilitiesCard: some View {
+        SettingsListCard {
+            unavailableRow(
+                icon: "bolt.horizontal.fill",
+                label: "Action execution",
+                sublabel: "Requires Phase 2 IPC — runtime adapter integration"
+            )
+            unavailableRow(
+                icon: "rectangle.3.group.fill",
+                label: "Workroom binding",
+                sublabel: "Requires MioServer human-auth cursor"
+            )
+            unavailableRow(
+                icon: "list.bullet.rectangle.fill",
+                label: "Log streaming",
+                sublabel: "Requires IPC socket integration"
+            )
+            unavailableRow(
+                icon: "arrow.up.circle.fill",
+                label: "Auto-upgrade (SMAppService)",
+                sublabel: "Requires upgrade.ts re-register mechanism",
+                isLast: true
+            )
+        }
+    }
+
+    // MARK: - View helpers
 
     @ViewBuilder
-    private func statusRow(icon: String, title: String, ok: Bool?, detail: String) -> some View {
+    private func lifecycleRow(
+        icon: String,
+        title: String,
+        path: String,
+        state: (String, Color),
+        isLast: Bool = false
+    ) -> some View {
         HStack(spacing: 10) {
             Image(systemName: icon)
-                .font(.system(size: 12))
+                .font(.system(size: 11))
                 .foregroundColor(Theme.subtleStrong)
-                .frame(width: 18)
+                .frame(width: 16)
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(Theme.detailText.opacity(0.9))
-                Text(detail)
+                Text(path)
                     .font(.system(size: 10))
                     .foregroundColor(Theme.subtle)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
+
             Spacer()
-            Circle()
-                .fill(dotColor(ok))
-                .frame(width: 8, height: 8)
-        }
-        .padding(.vertical, 4)
-    }
 
-    private func dotColor(_ ok: Bool?) -> Color {
-        switch ok {
-        case .some(true):  return Theme.success
-        case .some(false): return Theme.error
-        case .none:        return Theme.neutralDot
+            // State pill
+            Text(state.0)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(state.1)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(state.1.opacity(0.12))
+                .clipShape(Capsule())
         }
+        .padding(.vertical, 8)
     }
-
-    // MARK: - Control button
 
     @ViewBuilder
-    private func controlButton(
+    private func accentButton(
         label: String,
         icon: String,
         enabled: Bool,
-        destructive: Bool = false,
         action: @escaping () async -> Void
     ) -> some View {
         Button {
             Task { await action() }
         } label: {
-            HStack(spacing: 6) {
-                Image(systemName: icon).font(.system(size: 11))
-                Text(label).font(.system(size: 12, weight: .semibold))
+            HStack(spacing: 5) {
+                Image(systemName: icon).font(.system(size: 10))
+                Text(label).font(.system(size: 11, weight: .semibold))
             }
-            .foregroundColor(destructive ? Theme.destructiveText : Theme.backgroundInk)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .foregroundColor(enabled ? Theme.backgroundInk : Theme.subtle)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
             .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(destructive ? Theme.destructiveFill : Theme.accent)
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(enabled ? Theme.accent : Theme.controlFill)
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(destructive ? Theme.destructiveBorder : Color.clear, lineWidth: 0.5)
-            )
-            .opacity(enabled ? 1 : 0.4)
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
     }
 
-    // MARK: - Unavailable row
+    @ViewBuilder
+    private func outlineButton(
+        label: String,
+        icon: String,
+        enabled: Bool,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task { await action() }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: icon).font(.system(size: 10))
+                Text(label).font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundColor(enabled ? Theme.detailText.opacity(0.85) : Theme.subtle)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Theme.controlFill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7)
+                            .strokeBorder(Theme.controlBorder, lineWidth: 0.5)
+                    )
+            )
+            .opacity(enabled ? 1 : 0.55)
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
 
     @ViewBuilder
     private func unavailableRow(
@@ -267,7 +511,7 @@ struct AgentSettingsTab: View {
         isLast: Bool = false
     ) -> some View {
         SettingRow(icon: icon, label: label, sublabel: sublabel, isLast: isLast) {
-            Text(L10n.isChinese ? "即将推出" : "Soon")
+            Text("Soon")
                 .font(.system(size: 10, weight: .medium))
                 .foregroundColor(Theme.subtle)
                 .padding(.horizontal, 8)
@@ -278,40 +522,50 @@ struct AgentSettingsTab: View {
                         .overlay(Capsule().strokeBorder(Theme.controlBorder, lineWidth: 0.5))
                 )
         }
-        // Dim unavailable rows to signal non-interactive state
         .opacity(0.55)
     }
 
     // MARK: - Status probe
 
     private func refreshStatus() async {
-        // Binary presence
-        let binExists = FileManager.default.fileExists(atPath: binaryPath)
+        await MainActor.run { snap.phase = .checking }
 
-        // Process check via pgrep
-        let running = await shellCheck("pgrep", args: ["-x", "mio-agent"])
+        // Probe all fields concurrently where safe
+        let fm = FileManager.default
+        let binExists = fm.fileExists(atPath: binaryPath)
+        let sockExists = fm.fileExists(atPath: socketPath)
+        let logExists = fm.fileExists(atPath: logPath)
 
-        // Health endpoint ping (500ms timeout)
-        let healthy: Bool
-        if running {
-            healthy = await pingHealth()
-        } else {
-            healthy = false
-        }
+        // LaunchAgent loaded: launchctl list <label> exits 0 if found in current domain.
+        // Works from GUI app context (gui/<uid> domain). Shell context returns non-zero.
+        let launchLoaded = binExists ? await shellCheck("/bin/launchctl", args: ["list", launchLabel]) : false
+
+        // Process running via pgrep
+        let procRunning = await shellCheck("/usr/bin/pgrep", args: ["-x", "mio-agent"])
+
+        // Health endpoint (only meaningful when process is running)
+        let healthy = procRunning ? await pingHealth() : false
 
         await MainActor.run {
-            binaryExists = binExists
-            processRunning = running
-            healthReachable = healthy
+            snap.binaryExists = binExists
+            snap.launchAgentLoaded = binExists ? launchLoaded : false
+            snap.processRunning = procRunning
+            snap.healthReachable = healthy
+            snap.socketExists = sockExists
+            snap.logFileExists = logExists
+            snap.lastCheckedAt = Date()
 
+            // Phase determination (order matters)
             if !binExists {
-                status = .notInstalled
-            } else if !running {
-                status = .stopped
+                snap.phase = .notInstalled
+            } else if !launchLoaded {
+                snap.phase = .installedUnloaded
+            } else if !procRunning {
+                snap.phase = .loadedStopped
             } else if healthy {
-                status = .running
+                snap.phase = .runningHealthy
             } else {
-                status = .unhealthy
+                snap.phase = .runningUnhealthy
             }
         }
     }
@@ -327,12 +581,11 @@ struct AgentSettingsTab: View {
         }
     }
 
-    /// Returns true if the shell command exits 0.
     private func shellCheck(_ cmd: String, args: [String]) async -> Bool {
         await withCheckedContinuation { continuation in
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [cmd] + args
+            process.executableURL = URL(fileURLWithPath: cmd)
+            process.arguments = args
             process.standardOutput = FileHandle.nullDevice
             process.standardError = FileHandle.nullDevice
             do {
@@ -349,17 +602,14 @@ struct AgentSettingsTab: View {
 
     private func installAgent() async {
         await MainActor.run {
-            actionInProgress = true
-            lastActionMessage = L10n.isChinese ? "正在安装…" : "Installing…"
+            snap.phase = .starting
+            snap.lastDiagnostic = "Installing…"
         }
 
-        // Source: bundled binary in app Resources
         guard let srcPath = Bundle.main.path(forResource: "mio-agent", ofType: nil) else {
             await MainActor.run {
-                lastActionMessage = L10n.isChinese
-                    ? "错误：App bundle 中未找到 mio-agent 二进制"
-                    : "Error: mio-agent binary not found in app bundle"
-                actionInProgress = false
+                snap.phase = .error
+                snap.lastDiagnostic = "mio-agent was not found in the app bundle."
             }
             return
         }
@@ -368,108 +618,115 @@ struct AgentSettingsTab: View {
         let launchAgentsDir = (plistPath as NSString).deletingLastPathComponent
 
         do {
-            // Create directories
             try FileManager.default.createDirectory(atPath: mioDir, withIntermediateDirectories: true)
             try FileManager.default.createDirectory(atPath: launchAgentsDir, withIntermediateDirectories: true)
 
-            // Copy binary
             if FileManager.default.fileExists(atPath: binaryPath) {
                 try FileManager.default.removeItem(atPath: binaryPath)
             }
             try FileManager.default.copyItem(atPath: srcPath, toPath: binaryPath)
-
-            // Make executable
             try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryPath)
 
-            // Ad-hoc codesign (required for Keychain access on Apple Silicon)
+            // Ad-hoc codesign required on Apple Silicon for launchd/Keychain access
             await shellRun("/usr/bin/codesign", args: ["--sign", "-", "--force", binaryPath])
 
-            // Write LaunchAgent plist
             let plistContent = launchAgentPlist()
             try plistContent.write(toFile: plistPath, atomically: true, encoding: .utf8)
 
-            // Bootstrap with launchctl
+            // Bootstrap (register + start the job)
             let uid = "\(getuid())"
-            await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
-
-            await MainActor.run {
-                lastActionMessage = L10n.isChinese ? "安装完成" : "Installed"
+            let bootstrapExit = await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
+            if bootstrapExit != 0 {
+                await MainActor.run {
+                    snap.lastDiagnostic = "Could not register LaunchAgent. Check Logs for launchctl output."
+                }
+            } else {
+                await MainActor.run { snap.lastDiagnostic = nil }
             }
         } catch {
             await MainActor.run {
-                lastActionMessage = "Error: \(error.localizedDescription)"
+                snap.phase = .error
+                snap.lastDiagnostic = "Install failed: \(error.localizedDescription)"
             }
+            await refreshStatus()
+            return
         }
 
         await refreshStatus()
-        await MainActor.run { actionInProgress = false }
     }
 
     private func startAgent() async {
         await MainActor.run {
-            actionInProgress = true
-            lastActionMessage = L10n.isChinese ? "正在启动…" : "Starting…"
+            snap.phase = .starting
+            snap.lastDiagnostic = "Starting…"
         }
         let uid = "\(getuid())"
         // Bootstrap-first / kickstart-on-already-loaded pattern (idiomatic, no TOCTOU).
-        //
-        // Try `bootstrap` unconditionally:
-        //   - Not loaded → bootstrap succeeds (exit 0), job registered and started.
-        //   - Already loaded (process crashed or manually stopped) → bootstrap returns
-        //     non-zero ("service already loaded"); we fall back to `kickstart -k` which
-        //     restarts the process without re-registering the plist.
-        //
-        // This avoids a loaded-check TOCTOU race and sidesteps the `launchctl list` vs
-        // `launchctl print` exit-code ambiguity (which @运维 confirmed is unverifiable
-        // from a shell context — exit codes differ between shell and GUI app domains).
+        // - Not loaded → bootstrap succeeds (exit 0), job registered and started.
+        // - Already loaded → bootstrap returns non-zero ("service already loaded");
+        //   fall back to `kickstart -k` which restarts the process.
         let bootstrapExit = await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
         if bootstrapExit != 0 {
-            // Job already loaded — restart the (possibly stopped/crashed) process.
-            await shellRun("/bin/launchctl", args: ["kickstart", "-k", "user/\(uid)/\(launchLabel)"])
+            let kickExit = await shellRun("/bin/launchctl", args: ["kickstart", "-k", "user/\(uid)/\(launchLabel)"])
+            if kickExit != 0 {
+                await MainActor.run {
+                    snap.phase = .error
+                    snap.lastDiagnostic = "Could not start the loaded job. Check Logs."
+                }
+                await refreshStatus()
+                return
+            }
         }
         await refreshStatus()
         await MainActor.run {
-            lastActionMessage = processRunning
-                ? (L10n.isChinese ? "已启动" : "Started")
-                : (L10n.isChinese ? "启动失败，请检查日志" : "Failed to start — check Logs tab")
-            actionInProgress = false
+            if snap.phase != .runningHealthy && snap.phase != .runningUnhealthy {
+                snap.lastDiagnostic = "Start command sent — verify status above."
+            } else {
+                snap.lastDiagnostic = nil
+            }
         }
     }
 
     private func stopAgent() async {
         await MainActor.run {
-            actionInProgress = true
-            lastActionMessage = L10n.isChinese ? "正在停止…" : "Stopping…"
+            snap.phase = .stopping
+            snap.lastDiagnostic = "Stopping…"
         }
-        // Phase 2 IPC drain hook — currently a no-op.
-        // Phase 2: replace with real IPC drain — send drain request via agent.sock,
+
+        // TODO(Phase2): Replace with real IPC drain — send drain request via agent.sock,
         // wait for irreversible in-flight actions to reach transmission_complete or
-        // needs_human before proceeding, with a hard deadline (spec: 8s / ExitTimeOut=15s).
+        // needs_human (spec: 8s deadline), then proceed with bootout.
+        // Phase 1: no IPC, proceed directly to bootout.
         await requestDrain(deadlineMs: 8_000)
 
-        // Use `bootout` to fully unload the job. `kill SIGTERM` does NOT stop a
-        // KeepAlive job — launchd immediately restarts it after the process exits.
         let uid = "\(getuid())"
-        await shellRun("/bin/launchctl", args: ["bootout", "user/\(uid)/\(launchLabel)"])
+        let bootoutExit = await shellRun("/bin/launchctl", args: ["bootout", "user/\(uid)/\(launchLabel)"])
+        if bootoutExit != 0 {
+            await MainActor.run {
+                snap.phase = .error
+                snap.lastDiagnostic = "Could not unload LaunchAgent. Refresh status or check Logs."
+            }
+            await refreshStatus()
+            return
+        }
+
         await refreshStatus()
         await MainActor.run {
-            lastActionMessage = processRunning
-                ? (L10n.isChinese ? "进程仍在运行" : "Process still running")
-                : (L10n.isChinese ? "已停止" : "Stopped")
-            actionInProgress = false
+            if snap.processRunning {
+                snap.lastDiagnostic = "Process still running after stop request."
+            } else {
+                snap.lastDiagnostic = nil
+            }
         }
     }
 
     /// IPC drain stub — no-op in Phase 1.
     ///
-    /// Phase 2 implementation: open a Unix socket connection to `socketPath` (agent.sock),
-    /// send a drain request, and await acknowledgment that no irreversible actions are in-flight,
-    /// or until `deadlineMs` elapses (whichever comes first). On deadline, proceed with bootout
-    /// anyway — the agent's ExitTimeOut=15s provides a final safety window.
+    /// Phase 2 implementation: open a Unix socket to socketPath (agent.sock),
+    /// send a drain request, await acknowledgment or deadline.
+    /// On deadline, proceed with bootout — ExitTimeOut=15s provides a final safety window.
     private func requestDrain(deadlineMs: Int) async {
-        // Phase 1: no IPC socket exists yet. Return immediately.
-        // Phase 2: replace this body with real socket drain logic.
-        _ = deadlineMs  // suppress unused-warning; parameter intentional for Phase 2 signature
+        _ = deadlineMs  // intentional Phase 2 signature
     }
 
     @discardableResult
@@ -488,6 +745,22 @@ struct AgentSettingsTab: View {
                 continuation.resume(returning: -1)
             }
         }
+    }
+
+    // MARK: - Log helpers
+
+    private func openLogFile() {
+        let logURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".mio/agent.log")
+        NSWorkspace.shared.open(logURL)
+    }
+
+    private func copyLastLinesOfLog(count: Int) {
+        guard let content = try? String(contentsOfFile: logPath, encoding: .utf8) else { return }
+        let lines = content.components(separatedBy: "\n")
+        let lastLines = Array(lines.suffix(count)).joined(separator: "\n")
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(lastLines, forType: .string)
     }
 
     // MARK: - LaunchAgent plist

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -107,11 +107,11 @@ enum AgentLifecyclePhase: Equatable {
 /// Single view model passed through the UI.
 struct AgentLifecycleSnapshot {
     var binaryExists: Bool = false
+    var npxAvailable: Bool = false      // #117: npx-cached launch path is usable
     var configExists: Bool = false      // ~/.mio/agent.json — required before Start
     var launchAgentLoaded: Bool? = nil  // nil = probe not run yet
     var processRunning: Bool = false
     var healthReachable: Bool = false
-    var socketExists: Bool? = nil       // Phase 2: ~/.mio/agent.sock
     var logFileExists: Bool = false
     var phase: AgentLifecyclePhase = .checking
     var lastCheckedAt: Date? = nil
@@ -140,8 +140,6 @@ struct AgentSettingsTab: View {
         .appendingPathComponent(".mio/agent.json").path
     private let plistPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/LaunchAgents/io.miomioos.mio-agent.plist").path
-    private let socketPath = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".mio/agent.sock").path
     private let logPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".mio/agent.log").path
     private let mioDir = FileManager.default.homeDirectoryForCurrentUser
@@ -159,15 +157,20 @@ struct AgentSettingsTab: View {
             // MARK: Overall status card
             overallStatusCard
 
+            // MARK: Workspace status panel (#117) — this computer's workspace +
+            // daemon liveness + monitoring, all read from REAL local state.
+            SectionLabel(L10n.agentSectionWorkspace)
+            WorkspaceStatusPanel(snap: snap)
+
             // MARK: Lifecycle detail rows
             SectionLabel(L10n.agentSectionLifecycle)
             lifecycleDetailRows
 
             // MARK: Workspace enrollment (R2.1 — shells out to `mio-agent login`)
-            // Shown whenever the binary is installed. The card adapts: enroll
-            // form when unconfigured, status while enrolling, "already enrolled"
-            // once agent.json exists.
-            if snap.binaryExists {
+            // Shown whenever the daemon is launchable (npx-cached OR installed
+            // binary, #117). The card adapts: enroll form when unconfigured,
+            // status while enrolling, "already enrolled" once agent.json exists.
+            if snap.binaryExists || snap.npxAvailable {
                 SectionLabel(L10n.agentEnrollSection)
                 EnrollWorkspaceCard(
                     serverUrl: SyncManager.shared.serverUrl,
@@ -189,10 +192,6 @@ struct AgentSettingsTab: View {
             // MARK: Logs card
             SectionLabel(L10n.agentSectionLogs)
             logsCard
-
-            // MARK: Upcoming capabilities
-            SectionLabel(L10n.agentSectionCapabilities)
-            upcomingCapabilitiesCard
         }
         .task { await refreshStatus() }
     }
@@ -305,14 +304,7 @@ struct AgentSettingsTab: View {
                 state: snap.healthReachable
                     ? (L10n.agentStateOK, Theme.success)
                     : (snap.processRunning ? L10n.agentStateFailed : L10n.agentStateUnavailable,
-                       snap.processRunning ? Theme.error : Theme.neutralDot)
-            )
-            Divider().opacity(0.3)
-            lifecycleRow(
-                icon: "point.3.connected.trianglepath.dotted",
-                title: L10n.agentRowSocket,
-                path: "~/.mio/agent.sock",
-                state: (L10n.agentStateSocketPending, Theme.neutralDot),
+                       snap.processRunning ? Theme.error : Theme.neutralDot),
                 isLast: true
             )
         }
@@ -424,34 +416,6 @@ struct AgentSettingsTab: View {
         }
     }
 
-    // MARK: - Upcoming capabilities card
-
-    private var upcomingCapabilitiesCard: some View {
-        SettingsListCard {
-            unavailableRow(
-                icon: "bolt.horizontal.fill",
-                label: L10n.agentCapActionExecution,
-                sublabel: L10n.agentCapActionDesc
-            )
-            unavailableRow(
-                icon: "rectangle.3.group.fill",
-                label: L10n.agentCapWorkroom,
-                sublabel: L10n.agentCapWorkroomDesc
-            )
-            unavailableRow(
-                icon: "list.bullet.rectangle.fill",
-                label: L10n.agentCapLogStreaming,
-                sublabel: L10n.agentCapLogStreamingDesc
-            )
-            unavailableRow(
-                icon: "arrow.up.circle.fill",
-                label: L10n.agentCapAutoUpgrade,
-                sublabel: L10n.agentCapAutoUpgradeDesc,
-                isLast: true
-            )
-        }
-    }
-
     // MARK: - View helpers
 
     @ViewBuilder
@@ -550,27 +514,6 @@ struct AgentSettingsTab: View {
         .disabled(!enabled)
     }
 
-    @ViewBuilder
-    private func unavailableRow(
-        icon: String,
-        label: String,
-        sublabel: String,
-        isLast: Bool = false
-    ) -> some View {
-        SettingRow(icon: icon, label: label, sublabel: sublabel, isLast: isLast) {
-            Text(L10n.agentCapSoon)
-                .font(.system(size: 10, weight: .medium))
-                .foregroundColor(Theme.subtle)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(
-                    Capsule()
-                        .fill(Theme.controlFill)
-                        .overlay(Capsule().strokeBorder(Theme.controlBorder, lineWidth: 0.5))
-                )
-        }
-        .opacity(0.55)
-    }
 
     // MARK: - Status probe
 
@@ -580,8 +523,8 @@ struct AgentSettingsTab: View {
         // Probe all fields concurrently where safe
         let fm = FileManager.default
         let binExists = fm.fileExists(atPath: binaryPath)
+        let npxOK = MioAgentLauncher.npxAvailable
         let cfgExists = fm.fileExists(atPath: configPath)
-        let sockExists = fm.fileExists(atPath: socketPath)
         let logExists = fm.fileExists(atPath: logPath)
 
         // LaunchAgent loaded: `launchctl list <label>` exits 0 if the service is visible in the
@@ -598,16 +541,20 @@ struct AgentSettingsTab: View {
 
         await MainActor.run {
             snap.binaryExists = binExists
+            snap.npxAvailable = npxOK
             snap.configExists = cfgExists
             snap.launchAgentLoaded = binExists ? launchLoaded : false
             snap.processRunning = procRunning
             snap.healthReachable = healthy
-            snap.socketExists = sockExists
             snap.logFileExists = logExists
             snap.lastCheckedAt = Date()
 
-            // Phase determination (order matters)
-            if !binExists {
+            // Phase determination (order matters).
+            // #117: a usable npx-cached launcher counts as "installed" for the
+            // purpose of enrollment — the daemon can run via `npx` with no
+            // GitHub-binary download. Only fall to .notInstalled when NEITHER a
+            // binary nor npx is available.
+            if !binExists && !npxOK {
                 snap.phase = .notInstalled
             } else if !cfgExists {
                 // Binary installed but agent.json missing: user must run `mio-agent login` first.
@@ -681,23 +628,29 @@ struct AgentSettingsTab: View {
             try FileManager.default.createDirectory(atPath: mioDir, withIntermediateDirectories: true)
             try FileManager.default.createDirectory(atPath: launchAgentsDir, withIntermediateDirectories: true)
 
-            // Download, verify (SHA-256), extract, and atomically install the daemon binary
-            // from the GitHub Release artifact. This replaces the old bundle-lookup approach
-            // (Bundle.main.path forResource:"mio-agent") — the Resources phase is intentionally
-            // empty; the binary is always fetched fresh from the pinned release tag (#121).
-            //
-            // No-overwrite-on-fail: MioAgentDistribution only writes to binaryPath after all
-            // verification passes; any earlier failure leaves the existing binary intact.
-            try await MioAgentDistribution.downloadAndInstall(
-                to: binaryPath,
-                onProgress: { [self] msg in
-                    Task { @MainActor in snap.lastDiagnostic = msg }
-                }
-            )
+            // #117: npx-cached is the PREFERRED distribution. When npx is available
+            // we DON'T download/verify/codesign a GitHub-Release binary at all — the
+            // LaunchAgent plist invokes `npx -y @miomioos/mio-agent@<ver> run` and npm
+            // owns package integrity + caching. The GitHub-binary download remains the
+            // FALLBACK only when npx is absent.
+            if MioAgentLauncher.npxAvailable {
+                await MainActor.run { snap.lastDiagnostic = L10n.agentDiagUsingNpx }
+            } else {
+                // Fallback: download, verify (SHA-256), extract, and atomically install
+                // the daemon binary from the GitHub Release artifact (#121).
+                // No-overwrite-on-fail: MioAgentDistribution only writes to binaryPath
+                // after all verification passes; any earlier failure leaves it intact.
+                try await MioAgentDistribution.downloadAndInstall(
+                    to: binaryPath,
+                    onProgress: { [self] msg in
+                        Task { @MainActor in snap.lastDiagnostic = msg }
+                    }
+                )
 
-            // Ad-hoc codesign required on Apple Silicon for launchd/Keychain access
-            await MainActor.run { snap.lastDiagnostic = "Signing binary..." }
-            await shellRun("/usr/bin/codesign", args: ["--sign", "-", "--force", binaryPath])
+                // Ad-hoc codesign required on Apple Silicon for launchd/Keychain access.
+                await MainActor.run { snap.lastDiagnostic = L10n.agentDiagSigning }
+                await shellRun("/usr/bin/codesign", args: ["--sign", "-", "--force", binaryPath])
+            }
 
             let plistContent = launchAgentPlist()
             try plistContent.write(toFile: plistPath, atomically: true, encoding: .utf8)
@@ -774,12 +727,6 @@ struct AgentSettingsTab: View {
             snap.lastDiagnostic = L10n.agentDiagStopping
         }
 
-        // TODO(Phase2): Replace with real IPC drain — send drain request via agent.sock,
-        // wait for irreversible in-flight actions to reach transmission_complete or
-        // needs_human (spec: 8s deadline), then proceed with bootout.
-        // Phase 1: no IPC, proceed directly to bootout.
-        await requestDrain(deadlineMs: 8_000)
-
         let uid = "\(getuid())"
         let (bootoutExit, bootoutErr) = await shellRun("/bin/launchctl", args: ["bootout", "gui/\(uid)/\(launchLabel)"])
         if bootoutExit != 0 {
@@ -803,14 +750,6 @@ struct AgentSettingsTab: View {
         }
     }
 
-    /// IPC drain stub — no-op in Phase 1.
-    ///
-    /// Phase 2 implementation: open a Unix socket to socketPath (agent.sock),
-    /// send a drain request, await acknowledgment or deadline.
-    /// On deadline, proceed with bootout — ExitTimeOut=15s provides a final safety window.
-    private func requestDrain(deadlineMs: Int) async {
-        _ = deadlineMs  // intentional Phase 2 signature
-    }
 
     /// Returns (exitCode, stderrOutput). Stderr is captured so callers can surface real launchctl errors.
     @discardableResult
@@ -867,6 +806,36 @@ struct AgentSettingsTab: View {
 
     private func launchAgentPlist() -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
+
+        // #117: point ProgramArguments at the resolved launcher.
+        //   - npx-cached (preferred): npx -y @miomioos/mio-agent@<ver> run
+        //   - installed binary (fallback): ~/.mio/bin/mio-agent run
+        // launchd needs node on the child PATH for the npx case, so we also emit
+        // an EnvironmentVariables/PATH that includes the toolchain dir.
+        var programArgs: [String]
+        var pathEnvLine = ""
+        switch MioAgentLauncher.resolve() {
+        case .success(let launch):
+            programArgs = launch.argv(["run"])
+            if let dir = launch.toolchainDir {
+                pathEnvLine = """
+                    <key>EnvironmentVariables</key>
+                    <dict>
+                        <key>PATH</key>
+                        <string>\(dir):/usr/bin:/bin:/usr/sbin:/sbin</string>
+                    </dict>
+                """
+            }
+        case .failure:
+            // Should not happen (install gates on availability) — fall back to the
+            // canonical binary path so the plist is still well-formed.
+            programArgs = [binaryPath, "run"]
+        }
+
+        let argsXML = programArgs
+            .map { "        <string>\($0)</string>" }
+            .joined(separator: "\n")
+
         return """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -876,9 +845,9 @@ struct AgentSettingsTab: View {
             <string>\(launchLabel)</string>
             <key>ProgramArguments</key>
             <array>
-                <string>\(binaryPath)</string>
-                <string>run</string>
+        \(argsXML)
             </array>
+        \(pathEnvLine)
             <key>RunAtLoad</key>
             <true/>
             <key>KeepAlive</key>
@@ -892,6 +861,167 @@ struct AgentSettingsTab: View {
         </dict>
         </plist>
         """
+    }
+}
+
+// MARK: - WorkspaceStatusPanel (#117)
+
+/// Live status surface for THIS computer's workspace. Every row reads REAL state:
+///   - Workspace: enrolled name (host) + machine_id from ~/.mio/agent.json, or "Not enrolled".
+///   - Daemon: Online iff the process is running AND its local health endpoint returns 200
+///             (the same signals the lifecycle probe collects). The server's online window is
+///             driven by mio-agent's 45s machine heartbeat — surfaced in the hint, not faked.
+///   - Monitoring: derived from SyncManager's live connection state (claude/codex session sync).
+///   - Launch path: which #117 distribution strategy is resolved (npx-cached / binary / none).
+///
+/// NO hardcoded/placeholder rows — if a value is unknown it reads the unknown/offline state.
+private struct WorkspaceStatusPanel: View {
+    /// The lifecycle snapshot already probed by the parent tab (process + health + binary + npx).
+    let snap: AgentLifecycleSnapshot
+    @ObservedObject private var syncManager = SyncManager.shared
+
+    private var configPath: String {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".mio/agent.json").path
+    }
+
+    /// Parsed agent.json (server_url + machine_id) when enrolled, else nil.
+    private var enrolled: (serverUrl: String, machineId: String)? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: configPath)),
+              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return nil }
+        let server = (root["server_url"] as? String) ?? ""
+        let machine = (root["machine_id"] as? String) ?? ""
+        guard !machine.isEmpty else { return nil }
+        return (server, machine)
+    }
+
+    /// Workspace display name = this Mac's host name (1 computer = 1 workspace).
+    private var workspaceName: String { Host.current().localizedName ?? "Mac" }
+
+    /// Daemon is online only when the process runs AND its health endpoint answers 200.
+    private var daemonOnline: Bool { snap.processRunning && snap.healthReachable }
+
+    var body: some View {
+        SettingsListCard {
+            // Workspace row
+            statusRow(
+                icon: "macwindow",
+                title: L10n.wsRowWorkspace,
+                detail: enrolled != nil ? "\(workspaceName) · \(enrolled!.machineId.prefix(8))" : workspaceName,
+                state: enrolled != nil
+                    ? (snap.configExists ? (L10n.agentStateConfigPresent, Theme.success) : (L10n.wsWorkspaceUnconfigured, Theme.warning))
+                    : (L10n.wsWorkspaceUnconfigured, Theme.warning)
+            )
+            Divider().opacity(0.3)
+
+            // Daemon liveness row
+            statusRow(
+                icon: "bolt.heart.fill",
+                title: L10n.wsRowDaemon,
+                detail: L10n.wsDaemonHint,
+                state: daemonOnline
+                    ? (L10n.wsDaemonOnline, Theme.success)
+                    : (L10n.wsDaemonOffline, Theme.warning),
+                detailIsHint: true
+            )
+            Divider().opacity(0.3)
+
+            // Monitoring (session sync) row
+            statusRow(
+                icon: "dot.radiowaves.left.and.right",
+                title: L10n.wsRowMonitoring,
+                detail: monitoringDetail,
+                state: monitoringState
+            )
+            Divider().opacity(0.3)
+
+            // Launch path (#117 distribution strategy)
+            statusRow(
+                icon: "shippingbox.fill",
+                title: L10n.wsRowDistribution,
+                detail: distributionDetail,
+                state: distributionState,
+                isLast: true
+            )
+        }
+    }
+
+    // Monitoring is the existing CodeLight session-sync link (SyncManager).
+    private var monitoringDetail: String {
+        switch syncManager.connectionState {
+        case .connected:    return SyncManager.shared.serverUrl.flatMap { URL(string: $0)?.host } ?? ""
+        case .connecting, .authenticating: return ""
+        case .error(let m): return m
+        case .disconnected: return ""
+        }
+    }
+    private var monitoringState: (String, Color) {
+        switch syncManager.connectionState {
+        case .connected:    return (L10n.wsMonitoringOn, Theme.success)
+        case .connecting, .authenticating: return (L10n.wsMonitoringConnecting, .blue)
+        case .error:        return (L10n.wsMonitoringOff, Theme.error)
+        case .disconnected: return (L10n.wsMonitoringOff, Theme.neutralDot)
+        }
+    }
+
+    private var distributionDetail: String {
+        switch MioAgentLauncher.resolve() {
+        case .success(let l):
+            return l.kind == .npx ? MioAgentLauncher.npmSpec : MioAgentLauncher.installedBinaryPath
+        case .failure:
+            return ""
+        }
+    }
+    private var distributionState: (String, Color) {
+        switch MioAgentLauncher.resolve() {
+        case .success(let l): return l.kind == .npx ? (L10n.wsDistNpx, Theme.success) : (L10n.wsDistBinary, Theme.success)
+        case .failure:        return (L10n.wsDistNone, Theme.warning)
+        }
+    }
+
+    @ViewBuilder
+    private func statusRow(
+        icon: String,
+        title: String,
+        detail: String,
+        state: (String, Color),
+        detailIsHint: Bool = false,
+        isLast: Bool = false
+    ) -> some View {
+        HStack(alignment: detailIsHint ? .top : .center, spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundColor(Theme.subtleStrong)
+                .frame(width: 16)
+                .padding(.top, detailIsHint ? 2 : 0)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Theme.detailText.opacity(0.9))
+                if !detail.isEmpty {
+                    Text(detail)
+                        .font(.system(size: 10))
+                        .foregroundColor(Theme.subtle)
+                        .lineLimit(detailIsHint ? 3 : 1)
+                        .truncationMode(.middle)
+                        .fixedSize(horizontal: false, vertical: detailIsHint)
+                }
+            }
+
+            Spacer()
+
+            Text(state.0)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(state.1)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 3)
+                .background(state.1.opacity(0.12))
+                .clipShape(Capsule())
+                .padding(.top, detailIsHint ? 2 : 0)
+        }
+        .padding(.vertical, 8)
     }
 }
 

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -359,7 +359,7 @@ struct AgentSettingsTab: View {
                     .foregroundColor(Theme.subtle)
 
                 HStack(spacing: 8) {
-                    accentButton(label: "Open log file", icon: "doc.text", enabled: snap.binaryExists) {
+                    accentButton(label: "Open log file", icon: "doc.text", enabled: snap.logFileExists) {
                         openLogFile()
                     }
                     outlineButton(label: "Copy last 100 lines", icon: "doc.on.clipboard", enabled: snap.logFileExists) {

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -411,16 +411,21 @@ struct AgentSettingsTab: View {
             lastActionMessage = L10n.isChinese ? "正在启动…" : "Starting…"
         }
         let uid = "\(getuid())"
-        // Decide bootstrap vs kickstart based on whether the job is already loaded.
-        //   - Loaded (job in launchd domain, process may be stopped/crashed) → `kickstart -k`
-        //     to restart without re-registering the plist.
-        //   - Not loaded (after bootout or first install) → `bootstrap` to register the plist.
-        // This handles the edge case where the job is loaded but the process crashed:
-        // `bootstrap` would fail with "service already loaded"; `kickstart -k` restarts it.
-        if await isJobLoaded() {
+        // Bootstrap-first / kickstart-on-already-loaded pattern (idiomatic, no TOCTOU).
+        //
+        // Try `bootstrap` unconditionally:
+        //   - Not loaded → bootstrap succeeds (exit 0), job registered and started.
+        //   - Already loaded (process crashed or manually stopped) → bootstrap returns
+        //     non-zero ("service already loaded"); we fall back to `kickstart -k` which
+        //     restarts the process without re-registering the plist.
+        //
+        // This avoids a loaded-check TOCTOU race and sidesteps the `launchctl list` vs
+        // `launchctl print` exit-code ambiguity (which @运维 confirmed is unverifiable
+        // from a shell context — exit codes differ between shell and GUI app domains).
+        let bootstrapExit = await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
+        if bootstrapExit != 0 {
+            // Job already loaded — restart the (possibly stopped/crashed) process.
             await shellRun("/bin/launchctl", args: ["kickstart", "-k", "user/\(uid)/\(launchLabel)"])
-        } else {
-            await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
         }
         await refreshStatus()
         await MainActor.run {
@@ -453,20 +458,6 @@ struct AgentSettingsTab: View {
                 : (L10n.isChinese ? "已停止" : "Stopped")
             actionInProgress = false
         }
-    }
-
-    /// Check whether the LaunchAgent job is currently registered in the launchd user domain.
-    ///
-    /// Uses `launchctl list <label>` (exit 0 = loaded, non-zero = not found/error).
-    /// Empirically verified on macOS: `list` reliably returns exit 0 for a loaded job and
-    /// non-zero (e.g. 113) when the label is absent. `launchctl print user/<uid>/<label>`
-    /// was tested and found to return exit 113 even for a loaded job in some shell contexts,
-    /// so it is NOT used here despite appearing more domain-aware.
-    ///
-    /// Note: GUI app context (MioIsland launch) vs. shell context may differ. If behavior
-    /// diverges, add an app-context smoke test when the install path is validated end-to-end.
-    private func isJobLoaded() async -> Bool {
-        await shellCheck("launchctl", args: ["list", launchLabel])
     }
 
     /// IPC drain stub — no-op in Phase 1.

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -532,8 +532,14 @@ struct AgentSettingsTab: View {
         // which is correct since we bootstrap/kickstart/bootout into gui/$uid.
         let launchLoaded = binExists ? await shellCheck("/bin/launchctl", args: ["list", launchLabel]) : false
 
-        // Process running via pgrep
-        let procRunning = await shellCheck("/usr/bin/pgrep", args: ["-x", "mio-agent"])
+        // Process running via pgrep. Match the full command line ("-f") for
+        // "mio-agent run" rather than an exact process name ("-x mio-agent"):
+        // under the npx launch path the daemon runs as `node …/mio-agent run`
+        // (and its parent `npm exec …`), so `-x mio-agent` never matched it and
+        // the tab wrongly showed the daemon "stopped/offline" while it was
+        // actually running + healthy. "… run" keeps it specific enough to avoid
+        // matching unrelated processes that merely mention "mio-agent".
+        let procRunning = await shellCheck("/usr/bin/pgrep", args: ["-f", "mio-agent run"])
 
         // Health endpoint (only meaningful when process is running)
         let healthResult = procRunning ? await pingHealth() : (reachable: false, error: nil as String?)

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -456,12 +456,17 @@ struct AgentSettingsTab: View {
     }
 
     /// Check whether the LaunchAgent job is currently registered in the launchd user domain.
-    /// Uses the domain-aware form `launchctl print user/<uid>/<label>` (exit 0 = job loaded)
-    /// rather than legacy `launchctl list <label>`, consistent with the bootstrap/bootout/kickstart
-    /// domain specifiers used elsewhere in this file.
+    ///
+    /// Uses `launchctl list <label>` (exit 0 = loaded, non-zero = not found/error).
+    /// Empirically verified on macOS: `list` reliably returns exit 0 for a loaded job and
+    /// non-zero (e.g. 113) when the label is absent. `launchctl print user/<uid>/<label>`
+    /// was tested and found to return exit 113 even for a loaded job in some shell contexts,
+    /// so it is NOT used here despite appearing more domain-aware.
+    ///
+    /// Note: GUI app context (MioIsland launch) vs. shell context may differ. If behavior
+    /// diverges, add an app-context smoke test when the install path is validated end-to-end.
     private func isJobLoaded() async -> Bool {
-        let uid = "\(getuid())"
-        return await shellCheck("launchctl", args: ["print", "user/\(uid)/\(launchLabel)"])
+        await shellCheck("launchctl", args: ["list", launchLabel])
     }
 
     /// IPC drain stub — no-op in Phase 1.

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -61,47 +61,35 @@ enum AgentLifecyclePhase: Equatable {
 
     var primaryLabel: String {
         switch self {
-        case .checking:          return "Checking…"
-        case .notInstalled:      return "Not installed"
-        case .notConfigured:     return "Setup required"
-        case .installedUnloaded: return "Installed · stopped"
-        case .loadedStopped:     return "Loaded · not running"
-        case .starting:          return "Starting…"
-        case .runningHealthy:    return "Running"
-        case .runningUnhealthy:  return "Running · health check failed"
-        case .draining:          return "Stopping safely…"
-        case .stopping:          return "Stopping…"
-        case .error:             return "Action failed"
-        case .unknown:           return "Status unknown"
+        case .checking:          return L10n.agentPhaseLabelChecking
+        case .notInstalled:      return L10n.agentPhaseLabelNotInstalled
+        case .notConfigured:     return L10n.agentPhaseLabelNotConfigured
+        case .installedUnloaded: return L10n.agentPhaseLabelInstalledUnloaded
+        case .loadedStopped:     return L10n.agentPhaseLabelLoadedStopped
+        case .starting:          return L10n.agentPhaseLabelStarting
+        case .runningHealthy:    return L10n.agentPhaseLabelRunningHealthy
+        case .runningUnhealthy:  return L10n.agentPhaseLabelRunningUnhealthy
+        case .draining:          return L10n.agentPhaseLabelDraining
+        case .stopping:          return L10n.agentPhaseLabelStopping
+        case .error:             return L10n.agentPhaseLabelError
+        case .unknown:           return L10n.agentPhaseLabelUnknown
         }
     }
 
     var descriptionText: String {
         switch self {
-        case .checking:
-            return "Probing agent status…"
-        case .notInstalled:
-            return "Install the bundled mio-agent before starting local action execution."
-        case .notConfigured:
-            return "Agent is installed but not configured. Run mio-agent login in Terminal to set up before starting."
-        case .installedUnloaded:
-            return "The LaunchAgent is not running. Start it to prepare local action execution."
-        case .loadedStopped:
-            return "The job is loaded but the process is not running. Start will kickstart the job."
-        case .starting:
-            return "Wait; controls are disabled while the agent starts."
-        case .runningHealthy:
-            return "mio-agent is available on this Mac."
-        case .runningUnhealthy:
-            return "The process exists, but the local health endpoint did not respond."
-        case .draining:
-            return "Waiting for in-flight actions to reach a safe stopping point."
-        case .stopping:
-            return "The agent will be unloaded from launchd. Drain-safe stop is coming in Phase 2."
-        case .error:
-            return ""   // diagnostic carried in snap.lastDiagnostic
-        case .unknown:
-            return "Could not determine agent status. Refresh to try again."
+        case .checking:          return L10n.agentPhaseDescChecking
+        case .notInstalled:      return L10n.agentPhaseDescNotInstalled
+        case .notConfigured:     return L10n.agentPhaseDescNotConfigured
+        case .installedUnloaded: return L10n.agentPhaseDescInstalledUnloaded
+        case .loadedStopped:     return L10n.agentPhaseDescLoadedStopped
+        case .starting:          return L10n.agentPhaseDescStarting
+        case .runningHealthy:    return L10n.agentPhaseDescRunningHealthy
+        case .runningUnhealthy:  return L10n.agentPhaseDescRunningUnhealthy
+        case .draining:          return L10n.agentPhaseDescDraining
+        case .stopping:          return L10n.agentPhaseDescStopping
+        case .error:             return ""   // diagnostic carried in snap.lastDiagnostic
+        case .unknown:           return L10n.agentPhaseDescUnknown
         }
     }
 
@@ -135,7 +123,7 @@ struct AgentLifecycleSnapshot {
         guard let date = lastCheckedAt else { return "" }
         let fmt = DateFormatter()
         fmt.dateFormat = "HH:mm"
-        return "Last checked \(fmt.string(from: date))"
+        return L10n.agentLastChecked(fmt.string(from: date))
     }
 }
 
@@ -163,7 +151,7 @@ struct AgentSettingsTab: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             // Description
-            Text("Mio Agent is a background daemon that communicates with AI runtimes, fires actions, and reports results to MioServer.")
+            Text(L10n.agentTabDescription)
                 .font(.system(size: 11))
                 .foregroundColor(Theme.subtle)
 
@@ -171,19 +159,19 @@ struct AgentSettingsTab: View {
             overallStatusCard
 
             // MARK: Lifecycle detail rows
-            SectionLabel("Lifecycle")
+            SectionLabel(L10n.agentSectionLifecycle)
             lifecycleDetailRows
 
             // MARK: Controls
-            SectionLabel("Controls")
+            SectionLabel(L10n.agentSectionControls)
             controlsCard
 
             // MARK: Logs card
-            SectionLabel("Logs")
+            SectionLabel(L10n.agentSectionLogs)
             logsCard
 
             // MARK: Upcoming capabilities
-            SectionLabel("Capabilities (coming soon)")
+            SectionLabel(L10n.agentSectionCapabilities)
             upcomingCapabilitiesCard
         }
         .task { await refreshStatus() }
@@ -213,7 +201,7 @@ struct AgentSettingsTab: View {
                         .foregroundColor(Theme.detailText)
 
                     let desc = snap.phase == .error
-                        ? (snap.lastDiagnostic ?? "An error occurred.")
+                        ? (snap.lastDiagnostic ?? L10n.agentDiagErrorFallback)
                         : snap.phase.descriptionText
                     if !desc.isEmpty {
                         Text(desc)
@@ -252,54 +240,59 @@ struct AgentSettingsTab: View {
         SettingsListCard {
             lifecycleRow(
                 icon: "doc.fill",
-                title: "Binary",
+                title: L10n.agentRowBinary,
                 path: binaryPath,
-                state: snap.binaryExists ? ("Installed", Theme.success) : ("Missing", Theme.error)
+                state: snap.binaryExists
+                    ? (L10n.agentStateInstalled, Theme.success)
+                    : (L10n.agentStateMissing, Theme.error)
             )
             Divider().opacity(0.3)
             lifecycleRow(
                 icon: "gearshape.fill",
-                title: "Config",
+                title: L10n.agentRowConfig,
                 path: configPath,
-                state: snap.configExists ? ("Present", Theme.success) : ("Missing — run mio-agent login", Theme.warning)
+                state: snap.configExists
+                    ? (L10n.agentStateConfigPresent, Theme.success)
+                    : (L10n.agentStateConfigMissing, Theme.warning)
             )
             Divider().opacity(0.3)
             lifecycleRow(
                 icon: "gear",
-                title: "LaunchAgent",
+                title: L10n.agentRowLaunchAgent,
                 path: launchLabel,
                 state: {
                     switch snap.launchAgentLoaded {
-                    case .some(true):  return ("Loaded", Theme.success)
-                    case .some(false): return ("Unloaded", Theme.warning)
-                    case .none:        return ("Unknown", Theme.neutralDot)
+                    case .some(true):  return (L10n.agentStateLoaded, Theme.success)
+                    case .some(false): return (L10n.agentStateUnloaded, Theme.warning)
+                    case .none:        return (L10n.agentStateUnknown, Theme.neutralDot)
                     }
                 }()
             )
             Divider().opacity(0.3)
             lifecycleRow(
                 icon: "bolt.fill",
-                title: "Process",
+                title: L10n.agentRowProcess,
                 path: "mio-agent",
                 state: snap.processRunning
-                    ? ("Running", Theme.success)
-                    : ("Stopped", Theme.warning)
+                    ? (L10n.agentStateRunning, Theme.success)
+                    : (L10n.agentStateStopped, Theme.warning)
             )
             Divider().opacity(0.3)
             lifecycleRow(
                 icon: "heart.fill",
-                title: "Health",
+                title: L10n.agentRowHealth,
                 path: "127.0.0.1:7878",
                 state: snap.healthReachable
-                    ? ("OK", Theme.success)
-                    : (snap.processRunning ? "Failed" : "Unavailable", snap.processRunning ? Theme.error : Theme.neutralDot)
+                    ? (L10n.agentStateOK, Theme.success)
+                    : (snap.processRunning ? L10n.agentStateFailed : L10n.agentStateUnavailable,
+                       snap.processRunning ? Theme.error : Theme.neutralDot)
             )
             Divider().opacity(0.3)
             lifecycleRow(
                 icon: "point.3.connected.trianglepath.dotted",
-                title: "Socket",
+                title: L10n.agentRowSocket,
                 path: "~/.mio/agent.sock",
-                state: ("Pending Phase 2", Theme.neutralDot),
+                state: (L10n.agentStateSocketPending, Theme.neutralDot),
                 isLast: true
             )
         }
@@ -314,7 +307,7 @@ struct AgentSettingsTab: View {
                 // Install: shown when not installed
                 if !snap.binaryExists {
                     accentButton(
-                        label: "Install",
+                        label: L10n.agentButtonInstall,
                         icon: "arrow.down.circle.fill",
                         enabled: !snap.isBusy
                     ) { await installAgent() }
@@ -324,7 +317,7 @@ struct AgentSettingsTab: View {
                 if snap.binaryExists && snap.configExists && !snap.processRunning
                     && snap.phase != .starting && snap.phase != .stopping {
                     accentButton(
-                        label: "Start",
+                        label: L10n.agentButtonStart,
                         icon: "play.fill",
                         enabled: !snap.isBusy
                     ) { await startAgent() }
@@ -334,7 +327,7 @@ struct AgentSettingsTab: View {
                 if snap.processRunning || snap.launchAgentLoaded == true {
                     if snap.phase != .starting && snap.phase != .stopping {
                         outlineButton(
-                            label: "Stop",
+                            label: L10n.agentButtonStop,
                             icon: "stop.fill",
                             enabled: !snap.isBusy
                         ) { await stopAgent() }
@@ -358,7 +351,7 @@ struct AgentSettingsTab: View {
             // Setup required hint: shown when agent.json is missing
             if snap.phase == .notConfigured {
                 VStack(alignment: .leading, spacing: 5) {
-                    Text("Run this command in Terminal, then enter your server URL (e.g. https://mio.wdao.chat) when prompted:")
+                    Text(L10n.agentSetupHintCommand)
                         .font(.system(size: 10))
                         .foregroundColor(Theme.subtle)
                         .fixedSize(horizontal: false, vertical: true)
@@ -379,7 +372,7 @@ struct AgentSettingsTab: View {
                                 .foregroundColor(Theme.subtle)
                         }
                         .buttonStyle(.plain)
-                        .help("Copy command")
+                        .help(L10n.agentSetupHintCopy)
                     }
                 }
                 .padding(.top, 4)
@@ -401,21 +394,21 @@ struct AgentSettingsTab: View {
     private var logsCard: some View {
         SettingsCard {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Use logs for install/start/stop diagnostics. Sensitive values are not expected here.")
+                Text(L10n.agentLogsHint)
                     .font(.system(size: 10))
                     .foregroundColor(Theme.subtle)
 
                 HStack(spacing: 8) {
-                    accentButton(label: "Open log file", icon: "doc.text", enabled: true) {
+                    accentButton(label: L10n.agentButtonOpenLog, icon: "doc.text", enabled: true) {
                         openLogFile()
                     }
-                    outlineButton(label: "Copy last 100 lines", icon: "doc.on.clipboard", enabled: true) {
+                    outlineButton(label: L10n.agentButtonCopyLog, icon: "doc.on.clipboard", enabled: true) {
                         copyLastLinesOfLog(count: 100)
                     }
                 }
 
                 if !snap.logFileExists {
-                    Text("No agent log yet — ~/.mio/agent.log will be created once the agent starts successfully.")
+                    Text(L10n.agentLogsEmpty)
                         .font(.system(size: 10))
                         .foregroundColor(Theme.subtle.opacity(0.7))
                         .fixedSize(horizontal: false, vertical: true)
@@ -431,23 +424,23 @@ struct AgentSettingsTab: View {
         SettingsListCard {
             unavailableRow(
                 icon: "bolt.horizontal.fill",
-                label: "Action execution",
-                sublabel: "Requires Phase 2 IPC — runtime adapter integration"
+                label: L10n.agentCapActionExecution,
+                sublabel: L10n.agentCapActionDesc
             )
             unavailableRow(
                 icon: "rectangle.3.group.fill",
-                label: "Workroom binding",
-                sublabel: "Requires MioServer human-auth cursor"
+                label: L10n.agentCapWorkroom,
+                sublabel: L10n.agentCapWorkroomDesc
             )
             unavailableRow(
                 icon: "list.bullet.rectangle.fill",
-                label: "Log streaming",
-                sublabel: "Requires IPC socket integration"
+                label: L10n.agentCapLogStreaming,
+                sublabel: L10n.agentCapLogStreamingDesc
             )
             unavailableRow(
                 icon: "arrow.up.circle.fill",
-                label: "Auto-upgrade (SMAppService)",
-                sublabel: "Requires upgrade.ts re-register mechanism",
+                label: L10n.agentCapAutoUpgrade,
+                sublabel: L10n.agentCapAutoUpgradeDesc,
                 isLast: true
             )
         }
@@ -559,7 +552,7 @@ struct AgentSettingsTab: View {
         isLast: Bool = false
     ) -> some View {
         SettingRow(icon: icon, label: label, sublabel: sublabel, isLast: isLast) {
-            Text("Soon")
+            Text(L10n.agentCapSoon)
                 .font(.system(size: 10, weight: .medium))
                 .foregroundColor(Theme.subtle)
                 .padding(.horizontal, 8)
@@ -659,13 +652,13 @@ struct AgentSettingsTab: View {
     private func installAgent() async {
         await MainActor.run {
             snap.phase = .starting
-            snap.lastDiagnostic = "Installing…"
+            snap.lastDiagnostic = L10n.agentDiagInstalling
         }
 
         guard let srcPath = Bundle.main.path(forResource: "mio-agent", ofType: nil) else {
             await MainActor.run {
                 snap.phase = .error
-                snap.lastDiagnostic = "mio-agent was not found in the app bundle."
+                snap.lastDiagnostic = L10n.agentDiagBundleNotFound
             }
             return
         }
@@ -696,7 +689,7 @@ struct AgentSettingsTab: View {
             if bootstrapExit != 0 {
                 await MainActor.run {
                     snap.lastDiagnostic = bootstrapErr.isEmpty
-                        ? "Could not register LaunchAgent (launchctl exit \(bootstrapExit))."
+                        ? L10n.agentDiagBootstrapFailed(bootstrapExit)
                         : bootstrapErr
                 }
             } else {
@@ -705,7 +698,7 @@ struct AgentSettingsTab: View {
         } catch {
             await MainActor.run {
                 snap.phase = .error
-                snap.lastDiagnostic = "Install failed: \(error.localizedDescription)"
+                snap.lastDiagnostic = L10n.agentDiagInstallFailed(error.localizedDescription)
             }
             await refreshStatus()
             return
@@ -717,7 +710,7 @@ struct AgentSettingsTab: View {
     private func startAgent() async {
         await MainActor.run {
             snap.phase = .starting
-            snap.lastDiagnostic = "Starting…"
+            snap.lastDiagnostic = L10n.agentDiagStarting
         }
         let uid = "\(getuid())"
         // Bootstrap-first / kickstart-on-already-loaded pattern into gui/$uid
@@ -735,7 +728,7 @@ struct AgentSettingsTab: View {
                 } else if !bootstrapErr.isEmpty {
                     diagMsg = bootstrapErr
                 } else {
-                    diagMsg = "Start failed (bootstrap exit \(bootstrapExit), kickstart exit \(kickExit))."
+                    diagMsg = L10n.agentDiagStartFailed(bootstrapExit: bootstrapExit, kickExit: kickExit)
                 }
                 await MainActor.run {
                     snap.phase = .error
@@ -748,7 +741,7 @@ struct AgentSettingsTab: View {
         await refreshStatus()
         await MainActor.run {
             if snap.phase != .runningHealthy && snap.phase != .runningUnhealthy {
-                snap.lastDiagnostic = "Start command sent — verify status above."
+                snap.lastDiagnostic = L10n.agentDiagStartSent
             } else {
                 snap.lastDiagnostic = nil
             }
@@ -758,7 +751,7 @@ struct AgentSettingsTab: View {
     private func stopAgent() async {
         await MainActor.run {
             snap.phase = .stopping
-            snap.lastDiagnostic = "Stopping…"
+            snap.lastDiagnostic = L10n.agentDiagStopping
         }
 
         // TODO(Phase2): Replace with real IPC drain — send drain request via agent.sock,
@@ -773,7 +766,7 @@ struct AgentSettingsTab: View {
             await MainActor.run {
                 snap.phase = .error
                 snap.lastDiagnostic = bootoutErr.isEmpty
-                    ? "Could not unload LaunchAgent (launchctl exit \(bootoutExit))."
+                    ? L10n.agentDiagStopFailed(bootoutExit)
                     : bootoutErr
             }
             await refreshStatus()
@@ -783,7 +776,7 @@ struct AgentSettingsTab: View {
         await refreshStatus()
         await MainActor.run {
             if snap.processRunning {
-                snap.lastDiagnostic = "Process still running after stop request."
+                snap.lastDiagnostic = L10n.agentDiagProcessStillRunning
             } else {
                 snap.lastDiagnostic = nil
             }
@@ -844,7 +837,7 @@ struct AgentSettingsTab: View {
             NSPasteboard.general.setString(lastLines, forType: .string)
         } else {
             // No log file: copy last diagnostic so user can share it
-            let diag = snap.lastDiagnostic ?? "No agent log. The agent has not started successfully yet."
+            let diag = snap.lastDiagnostic ?? L10n.agentDiagNoLog
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(diag, forType: .string)
         }

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -536,8 +536,14 @@ struct AgentSettingsTab: View {
         let sockExists = fm.fileExists(atPath: socketPath)
         let logExists = fm.fileExists(atPath: logPath)
 
-        // LaunchAgent loaded: launchctl list <label> exits 0 if found in current domain.
-        // Works from GUI app context (gui/<uid> domain). Shell context returns non-zero.
+        // LaunchAgent loaded: `launchctl list <label>` exits 0 if the service is visible in the
+        // current launchctl session domain. Install uses `bootstrap user/$(uid)` (the user domain),
+        // not `gui/<uid>` (the GUI app domain) — these are distinct launchd domains in modern macOS.
+        // TODO(#79 smoke): verify in real MioIsland app context that this probe returns 0 for a
+        // job registered via `bootstrap user/$uid`. If it returns false-negative (job is loaded but
+        // probe returns 1), consider switching to `launchctl print user/$(uid)/<label>` to match
+        // the bootstrap domain, or checking the plist file existence as a fallback.
+        // This only affects status display (Start/Stop control flow uses bootstrap-first/kickstart).
         let launchLoaded = binExists ? await shellCheck("/bin/launchctl", args: ["list", launchLabel]) : false
 
         // Process running via pgrep

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -131,6 +131,7 @@ struct AgentLifecycleSnapshot {
 
 struct AgentSettingsTab: View {
     @State private var snap = AgentLifecycleSnapshot()
+    @ObservedObject private var enroller = MioAgentEnroller.shared
 
     // Known paths
     private let binaryPath = FileManager.default.homeDirectoryForCurrentUser
@@ -161,6 +162,25 @@ struct AgentSettingsTab: View {
             // MARK: Lifecycle detail rows
             SectionLabel(L10n.agentSectionLifecycle)
             lifecycleDetailRows
+
+            // MARK: Workspace enrollment (R2.1 — shells out to `mio-agent login`)
+            // Shown whenever the binary is installed. The card adapts: enroll
+            // form when unconfigured, status while enrolling, "already enrolled"
+            // once agent.json exists.
+            if snap.binaryExists {
+                SectionLabel(L10n.agentEnrollSection)
+                EnrollWorkspaceCard(
+                    serverUrl: SyncManager.shared.serverUrl,
+                    isConfigured: snap.configExists,
+                    onChanged: { Task { await refreshStatus() } }
+                )
+            }
+
+            // MARK: Autonomous agent block (plain JSON merge into agent.json)
+            if snap.configExists {
+                SectionLabel(L10n.agentAutoSection)
+                AutonomousAgentCard()
+            }
 
             // MARK: Controls
             SectionLabel(L10n.agentSectionControls)
@@ -348,32 +368,18 @@ struct AgentSettingsTab: View {
                 Spacer()
             }
 
-            // Setup required hint: shown when agent.json is missing
+            // Setup required hint: when agent.json is missing, point the user at
+            // the in-app Workspace enrollment card above. The old "run mio-agent
+            // login in Terminal" stub is retired (#R2.1) — enrollment is in-app.
             if snap.phase == .notConfigured {
-                VStack(alignment: .leading, spacing: 5) {
-                    Text(L10n.agentSetupHintCommand)
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(Theme.subtle)
+                    Text(L10n.agentPhaseDescNotConfigured)
                         .font(.system(size: 10))
                         .foregroundColor(Theme.subtle)
                         .fixedSize(horizontal: false, vertical: true)
-                    HStack(spacing: 6) {
-                        Text("mio-agent login")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(Theme.detailText)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Theme.controlFill)
-                            .clipShape(RoundedRectangle(cornerRadius: 5))
-                        Button {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString("mio-agent login", forType: .string)
-                        } label: {
-                            Image(systemName: "doc.on.clipboard")
-                                .font(.system(size: 10))
-                                .foregroundColor(Theme.subtle)
-                        }
-                        .buttonStyle(.plain)
-                        .help(L10n.agentSetupHintCopy)
-                    }
                 }
                 .padding(.top, 4)
             }
@@ -886,5 +892,409 @@ struct AgentSettingsTab: View {
         </dict>
         </plist>
         """
+    }
+}
+
+// MARK: - EnrollWorkspaceCard (R2.1 in-app enrollment)
+
+/// In-app workspace enrollment. Shells out to `mio-agent login` (which owns the
+/// Keychain + agent.json write) and surfaces the enroll intent it is polling so
+/// the Pair-iPhone QR can carry it (R2.7 dual QR). Replaces the retired
+/// "run mio-agent login in Terminal" stub.
+private struct EnrollWorkspaceCard: View {
+    /// The currently configured CodeLight/MioServer URL (from SyncManager).
+    let serverUrl: String?
+    /// True when ~/.mio/agent.json already exists (already enrolled).
+    let isConfigured: Bool
+    /// Called after a successful enroll or cancel so the parent re-probes status.
+    let onChanged: () -> Void
+
+    @ObservedObject private var enroller = MioAgentEnroller.shared
+    @State private var serverDraft: String = ""
+    @State private var deviceDraft: String = Host.current().localizedName ?? "Mac"
+
+    private var effectiveServer: String {
+        let s = serverDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return s.isEmpty ? (serverUrl ?? "") : s
+    }
+
+    private var isValidServer: Bool {
+        guard let u = URL(string: effectiveServer), let scheme = u.scheme?.lowercased() else { return false }
+        return (scheme == "https" || scheme == "http") && (u.host?.isEmpty == false)
+    }
+
+    var body: some View {
+        SettingsCard {
+            switch enroller.phase {
+            case .idle:
+                if isConfigured { alreadyConfiguredContent } else { enrollFormContent }
+            case .launching, .awaitingApproval:
+                inProgressContent
+            case .succeeded:
+                succeededContent
+            case .failed(let msg):
+                failedContent(msg)
+            }
+        }
+        .onAppear {
+            // Seed the server field from the configured URL so the user usually
+            // just clicks Enroll. Editable in case they want a different server.
+            if serverDraft.isEmpty { serverDraft = serverUrl ?? "" }
+        }
+    }
+
+    // MARK: States
+
+    private var enrollFormContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(L10n.agentEnrollNeededTitle)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(Theme.detailText)
+            Text(L10n.agentEnrollNeededBody)
+                .font(.system(size: 11))
+                .foregroundColor(Theme.subtle)
+                .fixedSize(horizontal: false, vertical: true)
+
+            labeledField(label: L10n.agentEnrollServerLabel,
+                         placeholder: L10n.agentEnrollServerPlaceholder,
+                         text: $serverDraft)
+            labeledField(label: L10n.agentEnrollDeviceLabel,
+                         placeholder: "Mac",
+                         text: $deviceDraft)
+
+            actionButton(
+                label: L10n.agentEnrollButtonStart,
+                icon: "person.badge.key.fill",
+                enabled: isValidServer
+            ) {
+                startEnroll()
+            }
+        }
+    }
+
+    private var inProgressContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small).scaleEffect(0.8)
+                Text(enroller.phase == .launching
+                     ? L10n.agentEnrollLaunching
+                     : L10n.agentEnrollAwaiting)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(Theme.detailText.opacity(0.9))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let intent = enroller.intent {
+                HStack(spacing: 6) {
+                    Image(systemName: "qrcode")
+                        .font(.system(size: 11))
+                        .foregroundColor(Theme.accent)
+                    Text("intent \(intent.intentId.prefix(8))")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(Theme.subtle)
+                    Spacer()
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(intent.deeplink, forType: .string)
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "doc.on.clipboard").font(.system(size: 10))
+                            Text(L10n.agentEnrollCopyDeeplink).font(.system(size: 10, weight: .medium))
+                        }
+                        .foregroundColor(Theme.subtleStrong)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            if !enroller.lastLine.isEmpty {
+                Text(enroller.lastLine)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundColor(Theme.subtle.opacity(0.8))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            outlineActionButton(label: L10n.agentEnrollButtonCancel, icon: "xmark") {
+                enroller.cancelEnrollment()
+                onChanged()
+            }
+        }
+    }
+
+    private var succeededContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 14))
+                    .foregroundColor(Theme.success)
+                Text(L10n.agentEnrollSucceeded)
+                    .font(.system(size: 12))
+                    .foregroundColor(Theme.detailText.opacity(0.9))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            actionButton(label: L10n.agentEnrollButtonDone, icon: "checkmark", enabled: true) {
+                enroller.reset()
+                onChanged()
+            }
+        }
+    }
+
+    private func failedContent(_ msg: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 13))
+                    .foregroundColor(Theme.error)
+                Text(msg)
+                    .font(.system(size: 11))
+                    .foregroundColor(Theme.error)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            actionButton(label: L10n.agentEnrollButtonRetry, icon: "arrow.clockwise", enabled: isValidServer) {
+                startEnroll()
+            }
+        }
+    }
+
+    private var alreadyConfiguredContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 13))
+                    .foregroundColor(Theme.success)
+                Text(L10n.agentEnrollAlreadyConfigured)
+                    .font(.system(size: 11))
+                    .foregroundColor(Theme.subtle)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            outlineActionButton(label: L10n.agentEnrollButtonReEnroll, icon: "arrow.triangle.2.circlepath") {
+                startEnroll()
+            }
+        }
+    }
+
+    // MARK: Actions
+
+    private func startEnroll() {
+        guard isValidServer else { return }
+        let server = effectiveServer.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = deviceDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        enroller.startEnrollment(
+            serverUrl: server,
+            deviceName: name.isEmpty ? (Host.current().localizedName ?? "Mac") : name
+        ) { _ in
+            // Intent parsed — the Pair-iPhone QR (observing enroller.intent)
+            // re-renders into a dual kind:"both" QR automatically.
+        }
+    }
+
+    // MARK: Field + button helpers (match tab styling)
+
+    private func labeledField(label: String, placeholder: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(Theme.subtle)
+            TextField(placeholder, text: text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(Theme.detailText.opacity(0.95))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Theme.fieldFill))
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Theme.fieldBorder, lineWidth: 0.5))
+        }
+    }
+
+    private func actionButton(label: String, icon: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: icon).font(.system(size: 10))
+                Text(label).font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundColor(enabled ? Theme.backgroundInk : Theme.subtle)
+            .padding(.horizontal, 10).padding(.vertical, 6)
+            .background(RoundedRectangle(cornerRadius: 7).fill(enabled ? Theme.accent : Theme.controlFill))
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
+
+    private func outlineActionButton(label: String, icon: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: icon).font(.system(size: 10))
+                Text(label).font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundColor(Theme.detailText.opacity(0.85))
+            .padding(.horizontal, 10).padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Theme.controlFill)
+                    .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(Theme.controlBorder, lineWidth: 0.5))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - AutonomousAgentCard (autonomous_agent block editor)
+
+/// Edits the optional `autonomous_agent` block in ~/.mio/agent.json. This is
+/// plain JSON (no Keychain), so we read/merge/write it in place WITHOUT
+/// disturbing any field `mio-agent login` wrote.
+private struct AutonomousAgentCard: View {
+    @ObservedObject private var enroller = MioAgentEnroller.shared
+
+    @State private var block = MioAgentEnroller.AutonomousAgentBlock.defaults
+    @State private var loaded = false
+    @State private var saveMessage: String? = nil
+    @State private var saveIsError = false
+
+    var body: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 12) {
+                // Enable toggle row
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(L10n.agentAutoEnabledLabel)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(Theme.detailText.opacity(0.92))
+                        Text(L10n.agentAutoEnabledSublabel)
+                            .font(.system(size: 11))
+                            .foregroundColor(Theme.subtle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $block.enabled)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .tint(Theme.accent)
+                }
+
+                if block.enabled {
+                    field(L10n.agentAutoWorkroomLabel, text: $block.workroom_id, mono: true)
+                    field(L10n.agentAutoChannelLabel, text: $block.channel_id, mono: true)
+                    field(L10n.agentAutoHandleLabel, text: $block.handle, mono: false)
+                    HStack(spacing: 8) {
+                        intField(L10n.agentAutoQuietLabel, value: $block.quiet_seconds)
+                        intField(L10n.agentAutoMaxRepliesLabel, value: $block.max_replies_per_window)
+                        intField(L10n.agentAutoWindowLabel, value: $block.window_seconds)
+                    }
+
+                    if !requiredFilled {
+                        Text(L10n.agentAutoRequiresWorkroom)
+                            .font(.system(size: 10))
+                            .foregroundColor(Theme.warning)
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    Button { save() } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: "tray.and.arrow.down.fill").font(.system(size: 10))
+                            Text(L10n.agentAutoSave).font(.system(size: 11, weight: .semibold))
+                        }
+                        .foregroundColor(saveEnabled ? Theme.backgroundInk : Theme.subtle)
+                        .padding(.horizontal, 10).padding(.vertical, 6)
+                        .background(RoundedRectangle(cornerRadius: 7).fill(saveEnabled ? Theme.accent : Theme.controlFill))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!saveEnabled)
+
+                    Button { clear() } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: "trash").font(.system(size: 10))
+                            Text(L10n.agentAutoClear).font(.system(size: 11, weight: .semibold))
+                        }
+                        .foregroundColor(Theme.detailText.opacity(0.85))
+                        .padding(.horizontal, 10).padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7)
+                                .fill(Theme.controlFill)
+                                .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(Theme.controlBorder, lineWidth: 0.5))
+                        )
+                    }
+                    .buttonStyle(.plain)
+
+                    Spacer()
+                }
+
+                if let msg = saveMessage {
+                    Text(msg)
+                        .font(.system(size: 10))
+                        .foregroundColor(saveIsError ? Theme.error : Theme.subtle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .onAppear { loadIfNeeded() }
+    }
+
+    private var requiredFilled: Bool {
+        !block.workroom_id.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !block.channel_id.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    /// Save is allowed when disabling (any state) or when enabling with the
+    /// required identifiers filled in.
+    private var saveEnabled: Bool { !block.enabled || requiredFilled }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+        if let existing = (try? enroller.readAutonomousBlock()) ?? nil {
+            block = existing
+        }
+    }
+
+    private func save() {
+        do {
+            try enroller.writeAutonomousBlock(block)
+            saveIsError = false
+            saveMessage = L10n.agentAutoSaved
+        } catch {
+            saveIsError = true
+            saveMessage = error.localizedDescription
+        }
+    }
+
+    private func clear() {
+        do {
+            try enroller.clearAutonomousBlock()
+            block = MioAgentEnroller.AutonomousAgentBlock.defaults
+            saveIsError = false
+            saveMessage = L10n.agentAutoSaved
+        } catch {
+            saveIsError = true
+            saveMessage = error.localizedDescription
+        }
+    }
+
+    private func field(_ label: String, text: Binding<String>, mono: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label).font(.system(size: 10, weight: .medium)).foregroundColor(Theme.subtle)
+            TextField("", text: text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: mono ? .monospaced : .default))
+                .foregroundColor(Theme.detailText.opacity(0.95))
+                .padding(.horizontal, 10).padding(.vertical, 8)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Theme.fieldFill))
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Theme.fieldBorder, lineWidth: 0.5))
+        }
+    }
+
+    private func intField(_ label: String, value: Binding<Int>) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label).font(.system(size: 10, weight: .medium)).foregroundColor(Theme.subtle).lineLimit(1)
+            TextField("", value: value, format: .number)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(Theme.detailText.opacity(0.95))
+                .padding(.horizontal, 10).padding(.vertical, 8)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Theme.fieldFill))
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Theme.fieldBorder, lineWidth: 0.5))
+        }
     }
 }

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -1,0 +1,487 @@
+//
+//  AgentSettingsTab.swift
+//  ClaudeIsland
+//
+//  Mio Agent settings tab — status monitoring, install/start/stop controls,
+//  and unavailable-capability rows for features pending Phase 2 IPC.
+//
+//  Phase 1 scope (task #70):
+//  - Status card: binary presence, process health, health endpoint ping
+//  - Controls card: Install / Start / Stop buttons via launchctl
+//  - Unavailable rows: Action execution, Workroom, Log streaming, SMAppService upgrade
+//
+//  Phase 2 (tracked separately): IPC socket, real-time status, Workroom binding.
+//
+
+import AppKit
+import Foundation
+import ServiceManagement
+import SwiftUI
+
+// MARK: - Agent Status
+
+private enum AgentStatus: Equatable {
+    case checking
+    case notInstalled   // ~/.mio/bin/mio-agent doesn't exist
+    case stopped        // binary present, not running
+    case running        // process alive + health endpoint reachable
+    case unhealthy      // process found but health endpoint timeout/error
+
+    var dotColor: Color {
+        switch self {
+        case .checking:     return Theme.neutralDot
+        case .notInstalled: return Theme.neutralDot
+        case .stopped:      return Theme.warning
+        case .running:      return Theme.success
+        case .unhealthy:    return Theme.error
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .checking:     return "检测中…"
+        case .notInstalled: return "未安装"
+        case .stopped:      return "已停止"
+        case .running:      return "运行中"
+        case .unhealthy:    return "进程存在但健康检测失败"
+        }
+    }
+}
+
+// MARK: - AgentSettingsTab
+
+struct AgentSettingsTab: View {
+    @State private var status: AgentStatus = .checking
+    @State private var binaryExists = false
+    @State private var processRunning = false
+    @State private var healthReachable = false
+    @State private var actionInProgress = false
+    @State private var lastActionMessage: String? = nil
+
+    // Known paths — Phase 2 may make these configurable
+    private let binaryPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".mio/bin/mio-agent").path
+    private let plistPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/LaunchAgents/io.miomioos.mio-agent.plist").path
+    private let socketPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".mio/agent.sock").path
+    private let healthURL = URL(string: "http://127.0.0.1:7878")!
+    private let launchLabel = "io.miomioos.mio-agent"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            // Header description
+            Text(L10n.isChinese
+                 ? "Mio Agent 是在本机后台运行的守护进程，负责与 AI runtime 通信、执行 action 并上报结果。"
+                 : "Mio Agent is a background daemon that communicates with AI runtimes, fires actions, and reports results to MioServer.")
+                .font(.system(size: 11))
+                .foregroundColor(Theme.subtle)
+
+            // MARK: Status card
+            SectionLabel(L10n.isChinese ? "状态" : "Status")
+            SettingsCard {
+                statusRow(
+                    icon: "cpu",
+                    title: L10n.isChinese ? "守护进程二进制" : "Daemon binary",
+                    ok: binaryExists ? true : false,
+                    detail: binaryExists ? binaryPath : (L10n.isChinese ? "未找到 — 请先安装" : "Not found — install first")
+                )
+                statusRow(
+                    icon: "bolt.fill",
+                    title: L10n.isChinese ? "进程状态" : "Process",
+                    ok: processRunning ? true : (binaryExists ? false : nil),
+                    detail: processRunning
+                        ? (L10n.isChinese ? "运行中" : "Running")
+                        : (L10n.isChinese ? "未运行" : "Not running")
+                )
+                statusRow(
+                    icon: "heart.fill",
+                    title: L10n.isChinese ? "健康端点" : "Health endpoint",
+                    ok: healthReachable ? true : (processRunning ? false : nil),
+                    detail: healthReachable
+                        ? "127.0.0.1:7878 ✓"
+                        : (L10n.isChinese ? "不可达" : "Unreachable")
+                )
+            }
+
+            // MARK: Controls card
+            SectionLabel(L10n.isChinese ? "控制" : "Controls")
+            SettingsCard {
+                HStack(spacing: 8) {
+                    // Install button — only relevant when binary is absent
+                    controlButton(
+                        label: L10n.isChinese ? "安装" : "Install",
+                        icon: "arrow.down.circle.fill",
+                        enabled: !binaryExists && !actionInProgress
+                    ) { await installAgent() }
+
+                    // Start / Stop toggle
+                    if processRunning {
+                        controlButton(
+                            label: L10n.isChinese ? "停止" : "Stop",
+                            icon: "stop.fill",
+                            enabled: binaryExists && !actionInProgress,
+                            destructive: true
+                        ) { await stopAgent() }
+                    } else {
+                        controlButton(
+                            label: L10n.isChinese ? "启动" : "Start",
+                            icon: "play.fill",
+                            enabled: binaryExists && !actionInProgress
+                        ) { await startAgent() }
+                    }
+
+                    // Refresh status
+                    Button {
+                        Task { await refreshStatus() }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(Theme.subtle)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(actionInProgress)
+                }
+
+                if let msg = lastActionMessage {
+                    Text(msg)
+                        .font(.system(size: 10))
+                        .foregroundColor(Theme.subtle)
+                        .padding(.top, 2)
+                }
+            }
+
+            // MARK: Unavailable capabilities
+            SectionLabel(L10n.isChinese ? "能力（待实现）" : "Capabilities (coming soon)")
+            SettingsListCard {
+                unavailableRow(
+                    icon: "bolt.horizontal.fill",
+                    label: L10n.isChinese ? "Action 执行" : "Action execution",
+                    sublabel: L10n.isChinese
+                        ? "需要 Phase 2 IPC — runtime adapter 对接"
+                        : "Requires Phase 2 IPC — runtime adapter integration"
+                )
+                unavailableRow(
+                    icon: "rectangle.3.group.fill",
+                    label: L10n.isChinese ? "Workroom 绑定" : "Workroom binding",
+                    sublabel: L10n.isChinese
+                        ? "需要 MioServer 人工 auth cursor"
+                        : "Requires MioServer human-auth cursor"
+                )
+                unavailableRow(
+                    icon: "list.bullet.rectangle.fill",
+                    label: L10n.isChinese ? "日志 streaming" : "Log streaming",
+                    sublabel: L10n.isChinese
+                        ? "需要 IPC socket 接入"
+                        : "Requires IPC socket integration"
+                )
+                unavailableRow(
+                    icon: "arrow.up.circle.fill",
+                    label: L10n.isChinese ? "自动升级（SMAppService）" : "Auto-upgrade (SMAppService)",
+                    sublabel: L10n.isChinese
+                        ? "需要 upgrade.ts re-register 机制"
+                        : "Requires upgrade.ts re-register mechanism",
+                    isLast: true
+                )
+            }
+        }
+        .task { await refreshStatus() }
+    }
+
+    // MARK: - Status row (reuse CmuxConnectionTab pattern)
+
+    @ViewBuilder
+    private func statusRow(icon: String, title: String, ok: Bool?, detail: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundColor(Theme.subtleStrong)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(Theme.detailText.opacity(0.9))
+                Text(detail)
+                    .font(.system(size: 10))
+                    .foregroundColor(Theme.subtle)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Circle()
+                .fill(dotColor(ok))
+                .frame(width: 8, height: 8)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func dotColor(_ ok: Bool?) -> Color {
+        switch ok {
+        case .some(true):  return Theme.success
+        case .some(false): return Theme.error
+        case .none:        return Theme.neutralDot
+        }
+    }
+
+    // MARK: - Control button
+
+    @ViewBuilder
+    private func controlButton(
+        label: String,
+        icon: String,
+        enabled: Bool,
+        destructive: Bool = false,
+        action: @escaping () async -> Void
+    ) -> some View {
+        Button {
+            Task { await action() }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: icon).font(.system(size: 11))
+                Text(label).font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundColor(destructive ? Theme.destructiveText : Theme.backgroundInk)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(destructive ? Theme.destructiveFill : Theme.accent)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(destructive ? Theme.destructiveBorder : Color.clear, lineWidth: 0.5)
+            )
+            .opacity(enabled ? 1 : 0.4)
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
+
+    // MARK: - Unavailable row
+
+    @ViewBuilder
+    private func unavailableRow(
+        icon: String,
+        label: String,
+        sublabel: String,
+        isLast: Bool = false
+    ) -> some View {
+        SettingRow(icon: icon, label: label, sublabel: sublabel, isLast: isLast) {
+            Text(L10n.isChinese ? "即将推出" : "Soon")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(Theme.subtle)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    Capsule()
+                        .fill(Theme.controlFill)
+                        .overlay(Capsule().strokeBorder(Theme.controlBorder, lineWidth: 0.5))
+                )
+        }
+        // Dim unavailable rows to signal non-interactive state
+        .opacity(0.55)
+    }
+
+    // MARK: - Status probe
+
+    private func refreshStatus() async {
+        // Binary presence
+        let binExists = FileManager.default.fileExists(atPath: binaryPath)
+
+        // Process check via pgrep
+        let running = await shellCheck("pgrep", args: ["-x", "mio-agent"])
+
+        // Health endpoint ping (500ms timeout)
+        let healthy: Bool
+        if running {
+            healthy = await pingHealth()
+        } else {
+            healthy = false
+        }
+
+        await MainActor.run {
+            binaryExists = binExists
+            processRunning = running
+            healthReachable = healthy
+
+            if !binExists {
+                status = .notInstalled
+            } else if !running {
+                status = .stopped
+            } else if healthy {
+                status = .running
+            } else {
+                status = .unhealthy
+            }
+        }
+    }
+
+    private func pingHealth() async -> Bool {
+        do {
+            var req = URLRequest(url: healthURL)
+            req.timeoutInterval = 0.5
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            return (resp as? HTTPURLResponse)?.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    /// Returns true if the shell command exits 0.
+    private func shellCheck(_ cmd: String, args: [String]) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [cmd] + args
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            do {
+                try process.run()
+                process.waitUntilExit()
+                continuation.resume(returning: process.terminationStatus == 0)
+            } catch {
+                continuation.resume(returning: false)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func installAgent() async {
+        await MainActor.run {
+            actionInProgress = true
+            lastActionMessage = L10n.isChinese ? "正在安装…" : "Installing…"
+        }
+
+        // Source: bundled binary in app Resources
+        guard let srcPath = Bundle.main.path(forResource: "mio-agent", ofType: nil) else {
+            await MainActor.run {
+                lastActionMessage = L10n.isChinese
+                    ? "错误：App bundle 中未找到 mio-agent 二进制"
+                    : "Error: mio-agent binary not found in app bundle"
+                actionInProgress = false
+            }
+            return
+        }
+
+        let mioDir = (binaryPath as NSString).deletingLastPathComponent
+        let launchAgentsDir = (plistPath as NSString).deletingLastPathComponent
+
+        do {
+            // Create directories
+            try FileManager.default.createDirectory(atPath: mioDir, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(atPath: launchAgentsDir, withIntermediateDirectories: true)
+
+            // Copy binary
+            if FileManager.default.fileExists(atPath: binaryPath) {
+                try FileManager.default.removeItem(atPath: binaryPath)
+            }
+            try FileManager.default.copyItem(atPath: srcPath, toPath: binaryPath)
+
+            // Make executable
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryPath)
+
+            // Ad-hoc codesign (required for Keychain access on Apple Silicon)
+            await shellRun("/usr/bin/codesign", args: ["--sign", "-", "--force", binaryPath])
+
+            // Write LaunchAgent plist
+            let plistContent = launchAgentPlist()
+            try plistContent.write(toFile: plistPath, atomically: true, encoding: .utf8)
+
+            // Bootstrap with launchctl
+            let uid = "\(getuid())"
+            await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
+
+            await MainActor.run {
+                lastActionMessage = L10n.isChinese ? "安装完成" : "Installed"
+            }
+        } catch {
+            await MainActor.run {
+                lastActionMessage = "Error: \(error.localizedDescription)"
+            }
+        }
+
+        await refreshStatus()
+        await MainActor.run { actionInProgress = false }
+    }
+
+    private func startAgent() async {
+        await MainActor.run {
+            actionInProgress = true
+            lastActionMessage = L10n.isChinese ? "正在启动…" : "Starting…"
+        }
+        let uid = "\(getuid())"
+        await shellRun("/bin/launchctl", args: ["kickstart", "-k", "user/\(uid)/\(launchLabel)"])
+        await refreshStatus()
+        await MainActor.run {
+            lastActionMessage = processRunning
+                ? (L10n.isChinese ? "已启动" : "Started")
+                : (L10n.isChinese ? "启动失败，请检查日志" : "Failed to start — check Logs tab")
+            actionInProgress = false
+        }
+    }
+
+    private func stopAgent() async {
+        await MainActor.run {
+            actionInProgress = true
+            lastActionMessage = L10n.isChinese ? "正在停止…" : "Stopping…"
+        }
+        let uid = "\(getuid())"
+        await shellRun("/bin/launchctl", args: ["kill", "SIGTERM", "user/\(uid)/\(launchLabel)"])
+        try? await Task.sleep(nanoseconds: 1_200_000_000)  // give process time to drain
+        await refreshStatus()
+        await MainActor.run {
+            lastActionMessage = processRunning
+                ? (L10n.isChinese ? "进程仍在运行" : "Process still running")
+                : (L10n.isChinese ? "已停止" : "Stopped")
+            actionInProgress = false
+        }
+    }
+
+    @discardableResult
+    private func shellRun(_ cmd: String, args: [String]) async -> Int32 {
+        await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: cmd)
+            process.arguments = args
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            do {
+                try process.run()
+                process.waitUntilExit()
+                continuation.resume(returning: process.terminationStatus)
+            } catch {
+                continuation.resume(returning: -1)
+            }
+        }
+    }
+
+    // MARK: - LaunchAgent plist
+
+    private func launchAgentPlist() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>\(launchLabel)</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>\(binaryPath)</string>
+                <string>run</string>
+            </array>
+            <key>RunAtLoad</key>
+            <true/>
+            <key>KeepAlive</key>
+            <true/>
+            <key>StandardOutPath</key>
+            <string>\(home)/.mio/agent.log</string>
+            <key>StandardErrorPath</key>
+            <string>\(home)/.mio/agent.log</string>
+        </dict>
+        </plist>
+        """
+    }
+}

--- a/ClaudeIsland/UI/Views/AgentSettingsTab.swift
+++ b/ClaudeIsland/UI/Views/AgentSettingsTab.swift
@@ -27,7 +27,8 @@ import SwiftUI
 enum AgentLifecyclePhase: Equatable {
     case checking           // initial probe in progress
     case notInstalled       // ~/.mio/bin/mio-agent missing
-    case installedUnloaded  // binary present, launchd job not loaded
+    case notConfigured      // binary present but ~/.mio/agent.json missing — needs `mio-agent login`
+    case installedUnloaded  // binary + config present, launchd job not loaded
     case loadedStopped      // job loaded, process not running
     case starting           // install/start command in progress
     case runningHealthy     // process running + health endpoint 200
@@ -43,6 +44,7 @@ enum AgentLifecyclePhase: Equatable {
         switch self {
         case .checking, .unknown:                return Theme.neutralDot
         case .notInstalled:                      return Theme.neutralDot
+        case .notConfigured:                     return Theme.warning
         case .installedUnloaded, .loadedStopped: return Theme.warning
         case .starting, .stopping, .draining:    return .blue
         case .runningHealthy:                    return Theme.success
@@ -61,6 +63,7 @@ enum AgentLifecyclePhase: Equatable {
         switch self {
         case .checking:          return "Checking…"
         case .notInstalled:      return "Not installed"
+        case .notConfigured:     return "Setup required"
         case .installedUnloaded: return "Installed · stopped"
         case .loadedStopped:     return "Loaded · not running"
         case .starting:          return "Starting…"
@@ -79,6 +82,8 @@ enum AgentLifecyclePhase: Equatable {
             return "Probing agent status…"
         case .notInstalled:
             return "Install the bundled mio-agent before starting local action execution."
+        case .notConfigured:
+            return "Agent is installed but not configured. Run mio-agent login in Terminal to set up before starting."
         case .installedUnloaded:
             return "The LaunchAgent is not running. Start it to prepare local action execution."
         case .loadedStopped:
@@ -114,6 +119,7 @@ enum AgentLifecyclePhase: Equatable {
 /// Single view model passed through the UI.
 struct AgentLifecycleSnapshot {
     var binaryExists: Bool = false
+    var configExists: Bool = false      // ~/.mio/agent.json — required before Start
     var launchAgentLoaded: Bool? = nil  // nil = probe not run yet
     var processRunning: Bool = false
     var healthReachable: Bool = false
@@ -141,12 +147,16 @@ struct AgentSettingsTab: View {
     // Known paths
     private let binaryPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".mio/bin/mio-agent").path
+    private let configPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".mio/agent.json").path
     private let plistPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/LaunchAgents/io.miomioos.mio-agent.plist").path
     private let socketPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".mio/agent.sock").path
     private let logPath = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".mio/agent.log").path
+    private let mioDir = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".mio")
     private let healthURL = URL(string: "http://127.0.0.1:7878")!
     private let launchLabel = "io.miomioos.mio-agent"
 
@@ -303,8 +313,8 @@ struct AgentSettingsTab: View {
                     ) { await installAgent() }
                 }
 
-                // Start: shown when installed + not running
-                if snap.binaryExists && !snap.processRunning
+                // Start: shown when installed + configured + not running
+                if snap.binaryExists && snap.configExists && !snap.processRunning
                     && snap.phase != .starting && snap.phase != .stopping {
                     accentButton(
                         label: "Start",
@@ -338,6 +348,35 @@ struct AgentSettingsTab: View {
                 Spacer()
             }
 
+            // Setup required hint: shown when agent.json is missing
+            if snap.phase == .notConfigured {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Run this command in Terminal to configure the agent:")
+                        .font(.system(size: 10))
+                        .foregroundColor(Theme.subtle)
+                    HStack(spacing: 6) {
+                        Text("mio-agent login")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(Theme.detailText)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Theme.controlFill)
+                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString("mio-agent login", forType: .string)
+                        } label: {
+                            Image(systemName: "doc.on.clipboard")
+                                .font(.system(size: 10))
+                                .foregroundColor(Theme.subtle)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Copy command")
+                    }
+                }
+                .padding(.top, 4)
+            }
+
             // Last action message / diagnostic
             if let diag = snap.lastDiagnostic {
                 Text(diag)
@@ -359,18 +398,19 @@ struct AgentSettingsTab: View {
                     .foregroundColor(Theme.subtle)
 
                 HStack(spacing: 8) {
-                    accentButton(label: "Open log file", icon: "doc.text", enabled: snap.logFileExists) {
+                    accentButton(label: "Open log file", icon: "doc.text", enabled: true) {
                         openLogFile()
                     }
-                    outlineButton(label: "Copy last 100 lines", icon: "doc.on.clipboard", enabled: snap.logFileExists) {
+                    outlineButton(label: "Copy last 100 lines", icon: "doc.on.clipboard", enabled: true) {
                         copyLastLinesOfLog(count: 100)
                     }
                 }
 
                 if !snap.logFileExists {
-                    Text("No agent log yet. Start the agent to create ~/.mio/agent.log.")
+                    Text("No agent log yet — ~/.mio/agent.log will be created once the agent starts successfully.")
                         .font(.system(size: 10))
                         .foregroundColor(Theme.subtle.opacity(0.7))
+                        .fixedSize(horizontal: false, vertical: true)
                         .padding(.top, 2)
                 }
             }
@@ -533,17 +573,13 @@ struct AgentSettingsTab: View {
         // Probe all fields concurrently where safe
         let fm = FileManager.default
         let binExists = fm.fileExists(atPath: binaryPath)
+        let cfgExists = fm.fileExists(atPath: configPath)
         let sockExists = fm.fileExists(atPath: socketPath)
         let logExists = fm.fileExists(atPath: logPath)
 
         // LaunchAgent loaded: `launchctl list <label>` exits 0 if the service is visible in the
-        // current launchctl session domain. Install uses `bootstrap user/$(uid)` (the user domain),
-        // not `gui/<uid>` (the GUI app domain) — these are distinct launchd domains in modern macOS.
-        // TODO(#79 smoke): verify in real MioIsland app context that this probe returns 0 for a
-        // job registered via `bootstrap user/$uid`. If it returns false-negative (job is loaded but
-        // probe returns 1), consider switching to `launchctl print user/$(uid)/<label>` to match
-        // the bootstrap domain, or checking the plist file existence as a fallback.
-        // This only affects status display (Start/Stop control flow uses bootstrap-first/kickstart).
+        // current launchctl session domain. From a GUI app process, this queries the gui/$uid domain,
+        // which is correct since we bootstrap/kickstart/bootout into gui/$uid.
         let launchLoaded = binExists ? await shellCheck("/bin/launchctl", args: ["list", launchLabel]) : false
 
         // Process running via pgrep
@@ -554,6 +590,7 @@ struct AgentSettingsTab: View {
 
         await MainActor.run {
             snap.binaryExists = binExists
+            snap.configExists = cfgExists
             snap.launchAgentLoaded = binExists ? launchLoaded : false
             snap.processRunning = procRunning
             snap.healthReachable = healthy
@@ -564,6 +601,11 @@ struct AgentSettingsTab: View {
             // Phase determination (order matters)
             if !binExists {
                 snap.phase = .notInstalled
+            } else if !cfgExists {
+                // Binary installed but agent.json missing: user must run `mio-agent login` first.
+                // Starting without config causes the agent to Fatal immediately and launchd
+                // restart-loops (KeepAlive=true) — block Start until config is present.
+                snap.phase = .notConfigured
             } else if !launchLoaded {
                 snap.phase = .installedUnloaded
             } else if !procRunning {
@@ -639,12 +681,15 @@ struct AgentSettingsTab: View {
             let plistContent = launchAgentPlist()
             try plistContent.write(toFile: plistPath, atomically: true, encoding: .utf8)
 
-            // Bootstrap (register + start the job)
+            // Bootstrap into gui/$uid — the correct launchd domain for LaunchAgents loaded
+            // from ~/Library/LaunchAgents/ in a GUI session (distinct from user/$uid).
             let uid = "\(getuid())"
-            let bootstrapExit = await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
+            let (bootstrapExit, bootstrapErr) = await shellRun("/bin/launchctl", args: ["bootstrap", "gui/\(uid)", plistPath])
             if bootstrapExit != 0 {
                 await MainActor.run {
-                    snap.lastDiagnostic = "Could not register LaunchAgent. Check Logs for launchctl output."
+                    snap.lastDiagnostic = bootstrapErr.isEmpty
+                        ? "Could not register LaunchAgent (launchctl exit \(bootstrapExit))."
+                        : bootstrapErr
                 }
             } else {
                 await MainActor.run { snap.lastDiagnostic = nil }
@@ -667,17 +712,26 @@ struct AgentSettingsTab: View {
             snap.lastDiagnostic = "Starting…"
         }
         let uid = "\(getuid())"
-        // Bootstrap-first / kickstart-on-already-loaded pattern (idiomatic, no TOCTOU).
+        // Bootstrap-first / kickstart-on-already-loaded pattern into gui/$uid
+        // (correct domain for LaunchAgents in ~/Library/LaunchAgents/ from a GUI session).
         // - Not loaded → bootstrap succeeds (exit 0), job registered and started.
-        // - Already loaded → bootstrap returns non-zero ("service already loaded");
+        // - Already loaded → bootstrap returns non-zero ("Bootstrap failed: 5");
         //   fall back to `kickstart -k` which restarts the process.
-        let bootstrapExit = await shellRun("/bin/launchctl", args: ["bootstrap", "user/\(uid)", plistPath])
+        let (bootstrapExit, bootstrapErr) = await shellRun("/bin/launchctl", args: ["bootstrap", "gui/\(uid)", plistPath])
         if bootstrapExit != 0 {
-            let kickExit = await shellRun("/bin/launchctl", args: ["kickstart", "-k", "user/\(uid)/\(launchLabel)"])
+            let (kickExit, kickErr) = await shellRun("/bin/launchctl", args: ["kickstart", "-k", "gui/\(uid)/\(launchLabel)"])
             if kickExit != 0 {
+                let diagMsg: String
+                if !kickErr.isEmpty {
+                    diagMsg = kickErr
+                } else if !bootstrapErr.isEmpty {
+                    diagMsg = bootstrapErr
+                } else {
+                    diagMsg = "Start failed (bootstrap exit \(bootstrapExit), kickstart exit \(kickExit))."
+                }
                 await MainActor.run {
                     snap.phase = .error
-                    snap.lastDiagnostic = "Could not start the loaded job. Check Logs."
+                    snap.lastDiagnostic = diagMsg
                 }
                 await refreshStatus()
                 return
@@ -706,11 +760,13 @@ struct AgentSettingsTab: View {
         await requestDrain(deadlineMs: 8_000)
 
         let uid = "\(getuid())"
-        let bootoutExit = await shellRun("/bin/launchctl", args: ["bootout", "user/\(uid)/\(launchLabel)"])
+        let (bootoutExit, bootoutErr) = await shellRun("/bin/launchctl", args: ["bootout", "gui/\(uid)/\(launchLabel)"])
         if bootoutExit != 0 {
             await MainActor.run {
                 snap.phase = .error
-                snap.lastDiagnostic = "Could not unload LaunchAgent. Refresh status or check Logs."
+                snap.lastDiagnostic = bootoutErr.isEmpty
+                    ? "Could not unload LaunchAgent (launchctl exit \(bootoutExit))."
+                    : bootoutErr
             }
             await refreshStatus()
             return
@@ -735,20 +791,25 @@ struct AgentSettingsTab: View {
         _ = deadlineMs  // intentional Phase 2 signature
     }
 
+    /// Returns (exitCode, stderrOutput). Stderr is captured so callers can surface real launchctl errors.
     @discardableResult
-    private func shellRun(_ cmd: String, args: [String]) async -> Int32 {
+    private func shellRun(_ cmd: String, args: [String]) async -> (Int32, String) {
         await withCheckedContinuation { continuation in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: cmd)
             process.arguments = args
             process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
+            let errPipe = Pipe()
+            process.standardError = errPipe
             do {
                 try process.run()
                 process.waitUntilExit()
-                continuation.resume(returning: process.terminationStatus)
+                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                let errStr = String(data: errData, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                continuation.resume(returning: (process.terminationStatus, errStr))
             } catch {
-                continuation.resume(returning: -1)
+                continuation.resume(returning: (-1, error.localizedDescription))
             }
         }
     }
@@ -756,17 +817,29 @@ struct AgentSettingsTab: View {
     // MARK: - Log helpers
 
     private func openLogFile() {
-        let logURL = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".mio/agent.log")
-        NSWorkspace.shared.open(logURL)
+        if snap.logFileExists {
+            let logURL = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".mio/agent.log")
+            NSWorkspace.shared.open(logURL)
+        } else {
+            // No log yet — open ~/.mio/ directory so user can inspect the folder
+            NSWorkspace.shared.open(mioDir)
+        }
     }
 
     private func copyLastLinesOfLog(count: Int) {
-        guard let content = try? String(contentsOfFile: logPath, encoding: .utf8) else { return }
-        let lines = content.components(separatedBy: "\n")
-        let lastLines = Array(lines.suffix(count)).joined(separator: "\n")
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(lastLines, forType: .string)
+        if snap.logFileExists,
+           let content = try? String(contentsOfFile: logPath, encoding: .utf8) {
+            let lines = content.components(separatedBy: "\n")
+            let lastLines = Array(lines.suffix(count)).joined(separator: "\n")
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(lastLines, forType: .string)
+        } else {
+            // No log file: copy last diagnostic so user can share it
+            let diag = snap.lastDiagnostic ?? "No agent log. The agent has not started successfully yet."
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(diag, forType: .string)
+        }
     }
 
     // MARK: - LaunchAgent plist

--- a/ClaudeIsland/UI/Views/PairPhoneView.swift
+++ b/ClaudeIsland/UI/Views/PairPhoneView.swift
@@ -12,44 +12,54 @@ private func pairPhoneTheme() -> ThemeResolver {
     ThemeResolver(theme: NotchCustomizationStore.shared.customization.theme)
 }
 
-// MARK: - QR payload (R2.7 dual QR)
+// MARK: - QR payload (#118 — one QR = monitoring + workspace by default)
 
-/// Builds the JSON payload the CodeLight camera parses. A single scan can carry
-/// BOTH the monitoring shortCode AND an enrollment intent so the phone pairs
-/// monitoring AND configures the workspace daemon at once.
+/// Builds the JSON payload the CodeLight camera parses. A single scan carries
+/// BOTH the monitoring shortCode AND a workspace enrollment intent so the phone
+/// pairs monitoring AND configures the workspace daemon in one scan.
+///
+/// #118 default behavior: when this Mac is enrollable and not already enrolled,
+/// the QR surface proactively creates the enrollment intent on appear
+/// (MioAgentEnroller.ensureWorkspaceIntentForQR), so the EMITTED QR is `kind:"both"`
+/// by default — the user is NOT asked to scan twice. The single payload encodes
+/// everything CodeLight needs: one scan → device joins monitoring AND its workspace.
 ///
 /// Shape (coordinated with the CodeLight camera parser):
 ///   {
 ///     "server": "<url>",
 ///     "code": "<monitoring shortCode>",
-///     "enroll_intent_id": "<uuid>",   // present only when enrolling
-///     "enroll_code": "<opaque>",      // present only when enrolling
+///     "enroll_intent_id": "<uuid>",   // present when workspace pairing is offered
+///     "enroll_code": "<opaque>",      // present when workspace pairing is offered
 ///     "kind": "monitor" | "workspace" | "both"
 ///   }
-/// - kind "monitor"   → only the monitoring shortCode is present.
-/// - kind "workspace" → only an enrollment intent is present (no monitoring code).
-/// - kind "both"      → both are present (one scan does everything).
+/// - kind "both"      → DEFAULT: monitoring + workspace (one scan does everything).
+/// - kind "monitor"   → degraded: only monitoring (already enrolled, or daemon not
+///                       launchable — workspace setup never blocks the monitor pair).
+/// - kind "workspace" → only an enrollment intent (no monitoring code yet).
 enum PairQRPayload {
     static func make(serverUrl: String, shortCode: String?, enrollIntent: MioEnrollIntent?) -> Data? {
-        var payload: [String: String] = ["server": serverUrl]
-
         let hasMonitor = !(shortCode ?? "").isEmpty
-        if hasMonitor { payload["code"] = shortCode! }
 
+        // Workspace enrollment present → emit the SAME canonical `mio://enroll/<id>?code=…&server=…
+        // &name=…&platform=…&arch=…` deeplink that `mio-agent login` produces and CodeLight already
+        // parses. Single source of truth — no bespoke JSON. The monitoring shortCode rides along as
+        // an optional `monitor_code` query param so ONE scan does workspace + monitoring (#118).
         if let enroll = enrollIntent {
-            payload["enroll_intent_id"] = enroll.intentId
-            payload["enroll_code"] = enroll.opaqueCode
+            var deeplink = enroll.deeplink
+            if hasMonitor {
+                let encoded = shortCode!.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? shortCode!
+                deeplink += (deeplink.contains("?") ? "&" : "?") + "monitor_code=\(encoded)"
+            }
+            return deeplink.data(using: .utf8)
         }
 
-        let kind: String
-        switch (hasMonitor, enrollIntent != nil) {
-        case (true, true):  kind = "both"
-        case (false, true): kind = "workspace"
-        default:            kind = "monitor"
+        // Monitoring-only fallback (no workspace daemon enrolled): legacy { server, code } JSON,
+        // which CodeLight's monitoring branch still understands.
+        if hasMonitor {
+            return try? JSONSerialization.data(withJSONObject: ["server": serverUrl, "code": shortCode!])
         }
-        payload["kind"] = kind
 
-        return try? JSONSerialization.data(withJSONObject: payload)
+        return nil
     }
 
     /// Render `payload` JSON into a crisp, scannable QR NSImage.
@@ -259,6 +269,10 @@ private struct QRPairingContentView: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: 20))
         .onAppear {
+            // #118: one QR = monitoring + workspace by default. Proactively create
+            // a workspace enrollment intent (no-op if already enrolled / daemon
+            // unavailable) so the single QR carries both capabilities.
+            enroller.ensureWorkspaceIntentForQR(serverUrl: serverUrl)
             generateQRCode()
             Task { await refreshLinkedDevices() }
         }
@@ -296,8 +310,9 @@ private struct QRPairingContentView: View {
                 .overlay(ProgressView().tint(Self.cardText.opacity(0.45)))
         }
 
-        // "Scan or enter code"
-        Text("Scan or enter code")
+        // Caption — reflect "one scan = monitoring + workspace" (#118) when the
+        // QR carries a workspace enrollment intent (the default for an enrollable Mac).
+        Text(enroller.intent != nil ? L10n.pairScanCaptionBoth : "Scan or enter code")
             .font(.system(size: 12, weight: .medium))
             .foregroundColor(Self.cardText.opacity(0.6))
 
@@ -613,6 +628,8 @@ struct PairPhonePanelView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
+            // #118: one QR = monitoring + workspace by default (see QRPairingContentView).
+            enroller.ensureWorkspaceIntentForQR(serverUrl: serverUrl)
             generateQRCode()
             Task { await refreshLinkedDevices() }
         }
@@ -802,7 +819,9 @@ struct PairPhonePanelView: View {
             Text(L10n.pairPanelStepScanTitle)
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(theme.primaryText)
-            Text(L10n.pairPanelStepScanBody)
+            // #118: reflect that one scan pairs monitoring + workspace when the QR
+            // carries an enrollment intent (the default for an enrollable Mac).
+            Text(enroller.intent != nil ? L10n.pairPanelStepScanBodyBoth : L10n.pairPanelStepScanBody)
                 .font(.system(size: 11))
                 .foregroundColor(theme.secondaryText)
                 .multilineTextAlignment(.center)

--- a/ClaudeIsland/UI/Views/PairPhoneView.swift
+++ b/ClaudeIsland/UI/Views/PairPhoneView.swift
@@ -12,6 +12,60 @@ private func pairPhoneTheme() -> ThemeResolver {
     ThemeResolver(theme: NotchCustomizationStore.shared.customization.theme)
 }
 
+// MARK: - QR payload (R2.7 dual QR)
+
+/// Builds the JSON payload the CodeLight camera parses. A single scan can carry
+/// BOTH the monitoring shortCode AND an enrollment intent so the phone pairs
+/// monitoring AND configures the workspace daemon at once.
+///
+/// Shape (coordinated with the CodeLight camera parser):
+///   {
+///     "server": "<url>",
+///     "code": "<monitoring shortCode>",
+///     "enroll_intent_id": "<uuid>",   // present only when enrolling
+///     "enroll_code": "<opaque>",      // present only when enrolling
+///     "kind": "monitor" | "workspace" | "both"
+///   }
+/// - kind "monitor"   → only the monitoring shortCode is present.
+/// - kind "workspace" → only an enrollment intent is present (no monitoring code).
+/// - kind "both"      → both are present (one scan does everything).
+enum PairQRPayload {
+    static func make(serverUrl: String, shortCode: String?, enrollIntent: MioEnrollIntent?) -> Data? {
+        var payload: [String: String] = ["server": serverUrl]
+
+        let hasMonitor = !(shortCode ?? "").isEmpty
+        if hasMonitor { payload["code"] = shortCode! }
+
+        if let enroll = enrollIntent {
+            payload["enroll_intent_id"] = enroll.intentId
+            payload["enroll_code"] = enroll.opaqueCode
+        }
+
+        let kind: String
+        switch (hasMonitor, enrollIntent != nil) {
+        case (true, true):  kind = "both"
+        case (false, true): kind = "workspace"
+        default:            kind = "monitor"
+        }
+        payload["kind"] = kind
+
+        return try? JSONSerialization.data(withJSONObject: payload)
+    }
+
+    /// Render `payload` JSON into a crisp, scannable QR NSImage.
+    static func qrImage(from payload: Data) -> NSImage? {
+        guard let jsonString = String(data: payload, encoding: .utf8) else { return nil }
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(jsonString.utf8)
+        filter.correctionLevel = "M"
+        guard let outputImage = filter.outputImage else { return nil }
+        let scaled = outputImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+    }
+}
+
 // MARK: - Menu Row (inside NotchMenuView)
 
 struct PairPhoneRow: View {
@@ -138,6 +192,9 @@ final class QRPairingWindow {
 private struct QRPairingContentView: View {
     let onClose: () -> Void
     @ObservedObject private var syncManager = SyncManager.shared
+    /// Observe the enroller so the QR re-renders into a dual (kind:"both") QR
+    /// the moment an in-app `mio-agent login` parses its enrollment intent.
+    @ObservedObject private var enroller = MioAgentEnroller.shared
     @State private var qrImage: NSImage?
     @State private var deviceName = Host.current().localizedName ?? "Mac"
     @State private var isHoveringClose = false
@@ -206,6 +263,9 @@ private struct QRPairingContentView: View {
             Task { await refreshLinkedDevices() }
         }
         .onChange(of: shortCode) { _, _ in
+            generateQRCode()
+        }
+        .onChange(of: enroller.intent) { _, _ in
             generateQRCode()
         }
     }
@@ -488,29 +548,15 @@ private struct QRPairingContentView: View {
             qrImage = nil
             return
         }
-        // New payload format: {server, code}. iPhone parses these and calls
-        // POST /v1/pairing/code/redeem.
-        let payload: [String: String] = [
-            "server": url,
-            "code": shortCode ?? "",
-        ]
-
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
-              let jsonString = String(data: jsonData, encoding: .utf8) else { return }
-
-        let context = CIContext()
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = Data(jsonString.utf8)
-        filter.correctionLevel = "M"
-
-        guard let outputImage = filter.outputImage else { return }
-
-        let scale = CGAffineTransform(scaleX: 10, y: 10)
-        let scaledImage = outputImage.transformed(by: scale)
-
-        guard let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) else { return }
-
-        qrImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        // R2.7 dual QR: embed the monitoring shortCode AND (when an in-app
+        // enrollment is in flight) the enrollment intent the daemon is polling,
+        // so one scan does both. kind reflects which parts are present.
+        guard let payload = PairQRPayload.make(
+            serverUrl: url,
+            shortCode: shortCode,
+            enrollIntent: enroller.intent
+        ) else { return }
+        qrImage = PairQRPayload.qrImage(from: payload)
     }
 }
 
@@ -523,6 +569,7 @@ private struct QRPairingContentView: View {
 
 struct PairPhonePanelView: View {
     @ObservedObject private var syncManager = SyncManager.shared
+    @ObservedObject private var enroller = MioAgentEnroller.shared
     @State private var serverDraft = ""
     @State private var isSavingServer = false
     @State private var isEditingServer = false
@@ -570,6 +617,7 @@ struct PairPhonePanelView: View {
             Task { await refreshLinkedDevices() }
         }
         .onChange(of: shortCode) { _, _ in generateQRCode() }
+        .onChange(of: enroller.intent) { _, _ in generateQRCode() }
         .onChange(of: syncManager.connectionState) { _, _ in
             Task { await refreshLinkedDevices() }
         }
@@ -961,20 +1009,12 @@ struct PairPhonePanelView: View {
             qrImage = nil
             return
         }
-        let payload: [String: String] = [
-            "server": url,
-            "code": shortCode ?? "",
-        ]
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: payload),
-              let jsonString = String(data: jsonData, encoding: .utf8) else { return }
-
-        let context = CIContext()
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = Data(jsonString.utf8)
-        filter.correctionLevel = "M"
-        guard let outputImage = filter.outputImage else { return }
-        let scaled = outputImage.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
-        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return }
-        qrImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        // R2.7 dual QR — see QRPairingContentView.generateQRCode for the contract.
+        guard let payload = PairQRPayload.make(
+            serverUrl: url,
+            shortCode: shortCode,
+            enrollIntent: enroller.intent
+        ) else { return }
+        qrImage = PairQRPayload.qrImage(from: payload)
     }
 }

--- a/ClaudeIsland/UI/Views/SystemSettingsView.swift
+++ b/ClaudeIsland/UI/Views/SystemSettingsView.swift
@@ -165,6 +165,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
     case behavior
     case plugins
     case codelight       // Pair iPhone + Launch Presets merged
+    case agent           // Mio Agent daemon management
     case cmuxConnection  // diagnostics for phone→terminal relay
     case logs            // live DebugLogger tail
     case advanced
@@ -180,6 +181,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .behavior:       return "slider.horizontal.3"
         case .plugins:        return "puzzlepiece.extension.fill"
         case .codelight:      return "iphone.radiowaves.left.and.right"
+        case .agent:          return "cpu"
         case .cmuxConnection: return "terminal.fill"
         case .logs:           return "doc.text.magnifyingglass"
         case .advanced:       return "wrench.and.screwdriver.fill"
@@ -195,6 +197,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .behavior:       return L10n.tabBehavior
         case .plugins:        return "Plugins"
         case .codelight:      return L10n.tabCodeLight
+        case .agent:          return "Mio Agent"
         case .cmuxConnection: return L10n.tabCmuxConnection
         case .logs:           return L10n.tabLogs
         case .advanced:       return L10n.tabAdvanced
@@ -214,6 +217,7 @@ enum SettingsTab: String, CaseIterable, Identifiable {
         case .behavior:       return "Behavior"
         case .plugins:        return "Plugins & Extensions"
         case .codelight:      return "CodeLight"
+        case .agent:          return "Mio Agent"
         case .cmuxConnection: return "cmux Connection"
         case .logs:           return "Logs"
         case .advanced:       return "Advanced"
@@ -458,6 +462,7 @@ private struct SystemSettingsContentView: View {
                 case .behavior:       BehaviorTab()
                 case .plugins:        NativePluginStoreView()
                 case .codelight:      CodeLightTab()
+                case .agent:          AgentSettingsTab()
                 case .cmuxConnection: CmuxConnectionTab()
                 case .logs:           LogsTab()
                 case .advanced:       AdvancedTab()
@@ -634,7 +639,7 @@ private struct TabToggle: View {
 
 /// Section label above a card: uppercase, tracked, muted.
 /// Usage: `SectionLabel(L10n.someSection)` then `SettingsListCard { ... }`.
-private struct SectionLabel: View {
+struct SectionLabel: View {
     let text: String
     init(_ text: String) { self.text = text }
 
@@ -652,7 +657,7 @@ private struct SectionLabel: View {
 /// Card sized for a vertical list of SettingRow. Uses tight vertical padding
 /// so rows' own 12pt vertical padding drives the row height — matches the
 /// reference mock's `padding: '4px 16px'` row card.
-private struct SettingsListCard<Content: View>: View {
+struct SettingsListCard<Content: View>: View {
     @ViewBuilder let content: Content
 
     var body: some View {
@@ -676,7 +681,7 @@ private struct SettingsListCard<Content: View>: View {
 /// A single list row: optional icon tile, label, optional sublabel, control.
 /// `isLast` suppresses the bottom divider so the final row sits flush with the
 /// card's bottom padding.
-private struct SettingRow<Control: View>: View {
+struct SettingRow<Control: View>: View {
     let icon: String?
     let label: String
     let sublabel: String?

--- a/docs/productization/agent-tab-phase2-state-design.md
+++ b/docs/productization/agent-tab-phase2-state-design.md
@@ -1,0 +1,318 @@
+# MioIsland Agent Tab Phase 2 State Design (#90)
+
+Status: design / interaction spec for continuous UI lane.
+Scope: MioIsland Settings → Agent tab status, controls, drain/log states, and copy for Phase 2 prep.
+Non-goals: implement IPC, change launchctl behavior, or design Workroom binding execution flows.
+
+## 1. Purpose
+
+The Agent tab should make local `mio-agent` lifecycle state understandable without pretending Phase 2 IPC is already finished. The user needs to know whether the binary is installed, whether launchd has the job loaded, whether the process is running, whether the health endpoint is reachable, whether Stop is drain-safe, and where to inspect logs.
+
+This spec builds on the #70/#74 skeleton: install/start/stop already exist; Phase 2 should improve status clarity, loaded/running distinction, drain copy, and log affordances.
+
+## 2. Core Principle
+
+Separate **registration**, **process**, and **health**. A loaded LaunchAgent is not the same as a running process; a running process is not the same as a healthy agent.
+
+Do not collapse these into one ambiguous label.
+
+## 3. Status Model
+
+| State | Definition | Primary label | Dot | User meaning |
+|---|---|---|---|---|
+| `not_installed` | `~/.mio/bin/mio-agent` missing | `Not installed` | neutral gray | Install first. |
+| `installed_unloaded` | binary exists, launchd job not loaded | `Installed · stopped` | amber | Start will bootstrap the job. |
+| `loaded_stopped` | job loaded, process not running | `Loaded · not running` | amber | Start will kickstart the job. |
+| `starting` | install/start command in progress | `Starting...` | blue spinner | Wait; controls disabled. |
+| `running_healthy` | process running + health endpoint 200 | `Running` | green | Normal. |
+| `running_unhealthy` | process running but health endpoint timeout/error | `Running · health check failed` | red | Check logs; restart may help. |
+| `draining` | Stop requested, IPC drain in progress | `Stopping safely...` | blue spinner | Phase 2 only; waiting for in-flight actions. |
+| `stopping` | bootout in progress after drain/no-op | `Stopping...` | blue spinner | Controls disabled. |
+| `error` | install/start/stop command failed | `Action failed` | red | Show controlled diagnostic and Logs link. |
+| `unknown` | probe failed or data stale | `Status unknown` | gray | Refresh. |
+
+Phase 1/now may not distinguish every state in code yet. The UI should still be designed around this model so later probes can fill it in without redesign.
+
+## 4. Layout
+
+Keep the existing Settings tab structure but make the hierarchy more diagnostic:
+
+```text
+Mio Agent
+Local background daemon for runtime actions and status reporting.
+
+[Overall status card]
+  Running / Not installed / Health failed
+  Last checked 14:32 · Refresh
+
+[Lifecycle details]
+  Binary        installed / missing
+  LaunchAgent   loaded / unloaded
+  Process       running / stopped
+  Health        127.0.0.1:7878 reachable / unavailable
+  Socket        ~/.mio/agent.sock available / pending Phase 2
+
+[Controls]
+  Install / Start / Restart / Stop
+  helper text or last action message
+
+[Logs]
+  Open log file · Copy last 100 lines
+  latest redacted preview, if cheap
+
+[Unavailable / Phase 2 capabilities]
+  Workroom binding · Action execution · Log streaming · Auto-upgrade
+```
+
+## 5. Status Card Copy
+
+### Not Installed
+
+```text
+Not installed
+Install the bundled mio-agent before starting local action execution.
+```
+
+Primary action: `Install`.
+Secondary: none.
+
+### Installed / Stopped
+
+```text
+Installed · stopped
+The LaunchAgent is not running. Start it to prepare local action execution.
+```
+
+Primary action: `Start`.
+
+### Running Healthy
+
+```text
+Running
+mio-agent is available on this Mac.
+```
+
+Primary action: `Stop`.
+Secondary: `Restart` only when Phase 2 or #74 loaded handling is stable.
+
+### Running Unhealthy
+
+```text
+Running · health check failed
+The process exists, but the local health endpoint did not respond.
+```
+
+Primary action: `Restart`.
+Secondary: `Open logs`.
+
+### Draining
+
+```text
+Stopping safely...
+Waiting for in-flight actions to reach a safe stopping point.
+```
+
+Use only after real IPC drain exists. Until then, do not show this state.
+
+### Phase 1 Stop Copy
+
+Current no-op drain / bootout stop should use honest copy:
+
+```text
+Stopping...
+The agent will be unloaded from launchd. Drain-safe stop is coming in Phase 2.
+```
+
+Do not say:
+
+```text
+Safe stop complete
+All actions drained
+No work in flight
+```
+
+## 6. Controls
+
+| Control | Visible when | Enabled when | Copy / effect |
+|---|---|---|---|
+| `Install` | not installed | not busy | Copies bundled binary, writes plist, bootstrap. |
+| `Start` | installed + not running | not busy | Bootstrap-first, fallback kickstart. |
+| `Restart` | running/unhealthy or loaded | not busy | Future: kickstart loaded job. Optional for Phase 2. |
+| `Stop` | running or loaded | not busy | Drain request if available, then bootout. |
+| `Refresh` | always | not busy | Re-probe status. |
+| `Open logs` | binary installed or log file exists | always | Reveal or open `~/.mio/agent.log`. |
+
+### Button Hierarchy
+
+- Primary action uses accent fill (`Install`, `Start`, `Restart` when unhealthy).
+- `Stop` uses outline/destructive-tint, not full red fill unless an action is dangerous.
+- `Open logs` is secondary text/icon button.
+- Disabled buttons must keep readable text; use muted background rather than opacity below 0.5.
+
+## 7. Lifecycle Detail Rows
+
+Rows should be compact and scannable:
+
+```text
+[icon] Binary        ~/.mio/bin/mio-agent                 Installed
+[icon] LaunchAgent   io.miomioos.mio-agent                Loaded
+[icon] Process       pgrep mio-agent                      Running
+[icon] Health        127.0.0.1:7878                       OK
+[icon] Socket        ~/.mio/agent.sock                    Pending Phase 2
+```
+
+Use pill labels:
+
+- `Installed` / `Missing`
+- `Loaded` / `Unloaded`
+- `Running` / `Stopped`
+- `OK` / `Failed`
+- `Pending` for Phase 2-only rows
+
+Do not bury the path in a paragraph; use middle truncation for long paths.
+
+## 8. Logs Surface
+
+Phase 2 should add a logs card, even before live streaming:
+
+```text
+Logs
+Use logs for install/start/stop diagnostics. Sensitive values are not expected here; report any token/path leak.
+
+[Open log file] [Copy last 100 lines]
+```
+
+If a preview is shown:
+
+- max 8 lines;
+- monospace 10-11 pt;
+- redacted before display if token/path patterns are known;
+- never auto-upload logs.
+
+Empty state:
+
+```text
+No agent log yet. Start the agent to create ~/.mio/agent.log.
+```
+
+Error state:
+
+```text
+Could not read log file. Check file permissions or open it in Finder.
+```
+
+## 9. Drain-Safe Stop States
+
+Future IPC drain sequence:
+
+1. User taps `Stop`.
+2. If IPC unavailable, show Phase 1 stop confirmation/copy and proceed to bootout only if user confirms or current design allows direct stop.
+3. If IPC available, enter `draining`.
+4. Drain request sent to `~/.mio/agent.sock` with 8s deadline.
+5. UI shows one of:
+   - `No in-flight actions. Stopping...`
+   - `Waiting for 1 in-flight action...`
+   - `Drain deadline reached. Stopping agent; check action status in CodeLight.`
+6. Bootout runs.
+7. Refresh status.
+
+Important copy rule: if drain deadline is reached, the UI must not imply all work completed safely. It should point users to CodeLight action status.
+
+## 10. Error Copy
+
+Keep user-facing errors controlled and actionable:
+
+| Situation | Copy |
+|---|---|
+| bundled binary missing | `mio-agent was not found in the app bundle.` |
+| bootstrap fails | `Could not register LaunchAgent. Check Logs for launchctl output.` |
+| kickstart fails | `Could not start the loaded job. Check Logs.` |
+| bootout fails | `Could not unload LaunchAgent. Refresh status or check Logs.` |
+| process still running after stop | `Process still running after stop request.` |
+| health failed | `Process is running, but health check failed.` |
+
+Avoid raw shell output as primary copy. Raw exit codes may appear in a small diagnostic line, for example:
+
+```text
+launchctl bootstrap exited 5
+```
+
+Do not show secrets, tokens, or full environment dumps.
+
+## 11. Visual Language
+
+MioIsland Settings already uses quiet utility UI. Keep it dense and operational:
+
+- cards: existing `SettingsCard` / `SettingsListCard` style;
+- typography: small but high contrast;
+- status dots: green/amber/red/gray/blue spinner;
+- no mascot/illustration here;
+- avoid celebratory success art; this is an operator control panel;
+- use icons only to improve scanning, not decoration.
+
+## 12. Implementation Handoff
+
+Suggested view model fields:
+
+```swift
+struct AgentLifecycleSnapshot {
+    var binaryExists: Bool
+    var launchAgentLoaded: Bool?
+    var processRunning: Bool
+    var healthReachable: Bool
+    var socketExists: Bool?
+    var isBusy: Bool
+    var phase: AgentLifecyclePhase
+    var lastCheckedAt: Date?
+    var lastActionMessage: String?
+    var lastDiagnostic: String?
+}
+```
+
+Suggested phase enum:
+
+```swift
+enum AgentLifecyclePhase {
+    case checking
+    case notInstalled
+    case installedUnloaded
+    case loadedStopped
+    case starting
+    case runningHealthy
+    case runningUnhealthy
+    case draining
+    case stopping
+    case error
+    case unknown
+}
+```
+
+Suggested component split:
+
+- `AgentOverallStatusCard`
+- `AgentLifecycleRows`
+- `AgentControlButtons`
+- `AgentLogsCard`
+- `AgentPhase2CapabilitiesCard`
+
+## 13. Screenshot Checklist
+
+Before Phase 2 UI passes review, capture:
+
+1. Not installed: install CTA and no Start/Stop confusion.
+2. Installed stopped: Start primary, lifecycle rows show binary installed + unloaded/stopped.
+3. Running healthy: green status, Stop visible, health OK.
+4. Running unhealthy: red/amber status, Restart/Open logs emphasized.
+5. Stopping Phase 1: no drain-safe promise.
+6. Draining Phase 2 mock: waiting copy and deadline copy.
+7. Logs card empty and with preview.
+8. Long path truncation in binary/log rows.
+
+## 14. Acceptance Criteria
+
+- UI distinguishes installed, loaded, running, and healthy.
+- Stop copy does not imply drain-safe behavior until IPC exists.
+- Error states tell the user where to look next without dumping raw logs.
+- Logs affordance is visible enough for diagnostics but does not auto-upload or expose secrets.
+- Buttons remain readable when disabled.
+- Phase 2-only capabilities are labeled as pending, not silently broken.

--- a/docs/productization/daemon-installer-ux-i18n-review.md
+++ b/docs/productization/daemon-installer-ux-i18n-review.md
@@ -1,0 +1,172 @@
+# MioIsland Daemon Installer UX + i18n Review (#124)
+
+Status: UX / copy / i18n review for daemon distribution follow-up.
+Scope: MioIsland Settings -> Mio Agent install/update flow for downloading, verifying, staging, and replacing the `mio-agent` daemon binary.
+Non-goals: choose the release-hosting mechanism, implement downloader code, or change launchd behavior.
+
+## 1. Purpose
+
+The daemon distribution flow should make it clear which daemon binary is installed, whether a newer package is being downloaded, whether the package was verified, and whether the currently working daemon was preserved after a failure.
+
+The user should never have to infer whether Install replaced the fixed daemon with an older or unverified one.
+
+## 2. UX Principles
+
+1. **No overwrite before verification.** Download into a staging path, verify checksum, then atomically replace. If verification fails, the current daemon remains in place.
+2. **Preserve working state on failure.** Offline, partial download, hash mismatch, and manifest errors must say that the current daemon was kept.
+3. **Separate install/update from Start/Stop.** Downloading or replacing the binary is not the same as the daemon running. The Agent lifecycle rows should keep Binary / Config / LaunchAgent / Process / Health separate.
+4. **Use actionable diagnostics.** Show controlled categories and next action; do not show raw stack traces as primary UI.
+5. **No secrets in UI.** It is OK to show version, architecture, SHA256 prefix, server URL, and commit. Do not show machine token, org secrets, auth headers, credential aliases, or raw provider errors.
+
+## 3. Suggested Information Architecture
+
+Add one compact row to the existing Lifecycle card:
+
+```text
+Daemon package   0.1.0 (arm64) · verified SHA256   Current
+```
+
+Recommended row placement:
+
+```text
+Binary
+Daemon package
+Config
+LaunchAgent
+Process
+Health
+Socket
+```
+
+The row should show:
+
+- installed version, if known;
+- target version during update;
+- checksum verification status;
+- whether the installed binary includes required fixes such as `machine-api-v1-prefix` and `socketio-control-path`.
+
+Keep long commit/checksum values truncated in the visible row and expose full diagnostics only through Copy diagnostic.
+
+## 4. State Model And Copy
+
+| State | Primary copy EN | Primary copy zh-Hans | Secondary copy EN | Secondary copy zh-Hans | Primary action |
+|---|---|---|---|---|---|
+| `daemon_current` | Daemon installed | 守护进程已安装 | Current package is verified and ready to start. | 当前安装包已校验，可启动。 | Start |
+| `update_available` | Daemon update available | 有可用守护进程更新 | A newer verified package is available. | 有新的已验证安装包可用。 | Update |
+| `manifest_loading` | Checking release manifest... | 正在检查发布清单… | Looking for the latest daemon package. | 正在查找最新守护进程安装包。 | none |
+| `manifest_unavailable` | Release manifest unavailable | 发布清单不可用 | The current daemon was kept. Try again when the release server is reachable. | 已保留当前守护进程。请在发布服务器可访问后重试。 | Retry |
+| `unsupported_arch` | No daemon build for this Mac | 没有适用于此 Mac 的守护进程版本 | This Mac architecture is not included in the release manifest. | 发布清单中不包含此 Mac 架构。 | Copy diagnostic |
+| `download_queued` | Download ready | 下载已准备 | The daemon package can be downloaded and verified before install. | 可下载并校验守护进程安装包后再安装。 | Download |
+| `downloading` | Downloading mio-agent... | 正在下载 mio-agent… | Keep this window open. The current daemon has not been changed. | 请保持此窗口打开。当前守护进程尚未更改。 | Cancel |
+| `download_interrupted` | Download was interrupted | 下载中断 | The current daemon was kept. Retry will start a new download. | 已保留当前守护进程。重试将重新下载。 | Retry |
+| `offline` | Cannot reach release server | 无法连接发布服务器 | The current daemon was kept. Check your network and try again. | 已保留当前守护进程。请检查网络后重试。 | Retry |
+| `verifying` | Verifying download... | 正在校验下载… | Checking SHA256 before install. | 正在安装前检查 SHA256。 | none |
+| `hash_mismatch` | Download could not be verified | 下载文件未通过校验 | The downloaded file was discarded and the current daemon was kept. | 已丢弃下载文件，并保留当前守护进程。 | Retry |
+| `staging` | Preparing update... | 正在准备更新… | Moving the verified package into staging. | 正在将已校验安装包移入暂存区。 | none |
+| `replacing` | Replacing daemon safely... | 正在安全替换守护进程… | Do not quit MioIsland. The previous binary will be kept if replacement fails. | 请不要退出 MioIsland。替换失败时会保留旧版本。 | none |
+| `restart_required` | Restart agent to use the new daemon | 重启 agent 以使用新版守护进程 | The package is installed. Stop and Start the agent to load it. | 安装包已安装。请停止并重新启动 agent 以加载新版。 | Restart agent |
+| `updated` | Daemon updated | 守护进程已更新 | The verified daemon package is installed. | 已安装经过校验的守护进程安装包。 | Start |
+| `rollback_preserved` | Current daemon was kept | 已保留当前守护进程 | The update did not replace the working daemon. | 本次更新未替换当前可用守护进程。 | Retry |
+
+Avoid user-facing copy such as:
+
+- "Ignore checksum"
+- "Force replace"
+- "Maybe installed"
+- "Unknown error"
+- "Check Logs" without a visible diagnostic or copy action
+
+## 5. Button And Control Rules
+
+| Control | Visible when | Enabled when | Notes |
+|---|---|---|---|
+| `Download` / `Update` | release manifest has matching artifact | not busy | Starts download into staging only. |
+| `Retry` | offline, interrupted, manifest unavailable, hash mismatch | not busy | Must start from a fresh download or fresh manifest read. |
+| `Cancel` | downloading | downloader supports cancellation | Cancel must leave current daemon unchanged. |
+| `Start` | daemon package installed and Config present | not replacing/downloading | Do not show Start as the primary action while package replacement is active. |
+| `Stop` | daemon loaded/running | not replacing/downloading | If replacing while running is not supported, ask user to Stop before Update. |
+| `Restart agent` | `restart_required` | not busy | Should run the existing Stop/Start path after package replacement. |
+| `Open log file` | always | always | If installer log is missing, open `~/.mio/` rather than dead-disable. |
+| `Copy diagnostic` | always | always | Copy controlled state, version, arch, checksum prefix, and last error category. |
+
+If replacement fails, the next visible state should be `rollback_preserved`, not generic `failed`.
+
+## 6. Error Priority
+
+When multiple conditions exist, prioritize the one that tells the user the next action:
+
+1. Replacing / staging in progress
+2. Hash mismatch
+3. Partial download / interrupted
+4. Offline / release server unreachable
+5. Unsupported architecture
+6. Config missing
+7. LaunchAgent stopped
+8. Health failed
+
+Example: if the binary is installed but the release check is offline, show `Cannot reach release server` inside the installer row while the main lifecycle card can still show `Installed · stopped`.
+
+## 7. i18n Key Proposal
+
+MioIsland currently uses `L10n.*` in `Localization.swift`. Add installer keys under the existing Mio Agent Settings block rather than hard-coding strings in `AgentSettingsTab.swift`.
+
+Suggested key groups:
+
+```swift
+agentInstallerRowPackage
+agentInstallerStateCurrent
+agentInstallerStateUpdateAvailable
+agentInstallerStateManifestLoading
+agentInstallerStateManifestUnavailable
+agentInstallerStateUnsupportedArch
+agentInstallerStateDownloadQueued
+agentInstallerStateDownloading
+agentInstallerStateDownloadInterrupted
+agentInstallerStateOffline
+agentInstallerStateVerifying
+agentInstallerStateHashMismatch
+agentInstallerStateStaging
+agentInstallerStateReplacing
+agentInstallerStateRestartRequired
+agentInstallerStateUpdated
+agentInstallerStateRollbackPreserved
+agentInstallerActionDownload
+agentInstallerActionUpdate
+agentInstallerActionRetry
+agentInstallerActionCancel
+agentInstallerActionRestartAgent
+agentInstallerActionCopyDiagnostic
+agentInstallerHintCurrentKept
+agentInstallerHintChecksum
+agentInstallerHintNoOverwrite
+agentInstallerDiagCopied
+```
+
+Keep dynamic values in formatter helpers:
+
+```swift
+agentInstallerVersion(_ version: String, arch: String)
+agentInstallerChecksum(_ prefix: String)
+agentInstallerCommit(_ shortSha: String)
+agentInstallerDownloadProgress(_ percent: Int)
+```
+
+## 8. Visual Review Notes
+
+- Keep the existing Agent Settings visual language: compact diagnostic rows, pill states, restrained amber/green/red semantics, and Settings-native density.
+- Use spinner only for active work (`manifest_loading`, `downloading`, `verifying`, `staging`, `replacing`).
+- Hash mismatch should use error red, but the preserved-current-daemon note should be neutral/amber, not green success.
+- Success should not imply the daemon is running. Use `Daemon updated`, not `Agent running`.
+- Long paths and checksums should truncate in the row; Copy diagnostic carries the full value.
+
+## 9. Acceptance Checklist
+
+- English and Simplified Chinese copy exist for every installer state, button, and diagnostic.
+- Offline, hash mismatch, partial download, and manifest unavailable all explicitly say the current daemon was kept.
+- The UI never replaces a working daemon before checksum verification passes.
+- The UI does not expose tokens, auth headers, machine token, credential aliases, or raw provider errors.
+- Start/Stop lifecycle remains separate from package download/install state.
+- Running daemon replacement either requires Stop first or uses a verified bootout/bootstrap flow.
+- Copy diagnostic works even when no installer log exists.
+- A new/fresh machine cannot install an old daemon missing `machine-api-v1-prefix` and `socketio-control-path` fixes.
+- A failed update leaves the existing `~/.mio/bin/mio-agent` executable and launchd state recoverable.

--- a/scripts/safe-install-app.sh
+++ b/scripts/safe-install-app.sh
@@ -2,7 +2,12 @@
 # safe-install-app.sh — Replace /Applications/Mio Island.app without nesting.
 #
 # Usage:
-#   ./scripts/safe-install-app.sh /path/to/built/"Mio Island.app"
+#   ./scripts/safe-install-app.sh /path/to/built/"Mio Island.app" [--launch-verify]
+#
+# Flags:
+#   --launch-verify   After install, open the app and assert the running instance's
+#                     bundle path is /Applications/Mio Island.app (not DerivedData).
+#                     Exits non-zero if the wrong binary is running.
 #
 # What this script does (in order):
 #   1. Validates the source .app exists and is a real Mio Island bundle.
@@ -11,6 +16,9 @@
 #   4. Copies the new bundle into /Applications/.
 #   5. Clears Gatekeeper quarantine so the app opens without prompts.
 #   6. Verifies the installed CFBundleIdentifier matches the expected value.
+#   7. No-nesting assertion (ensures source was not nested inside target).
+#   8. [--launch-verify only] Opens the installed app and asserts lsappinfo shows
+#      bundle path = /Applications/Mio Island.app.
 #
 # Background (why this matters):
 #   `cp -R source.app /Applications/existing.app` nests source INSIDE destination
@@ -27,11 +35,36 @@ EXPECTED_BUNDLE_ID="com.codeisland.app"
 TARGET="/Applications/Mio Island.app"
 APP_PROCESS_NAME="Mio Island"
 
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+SOURCE=""
+LAUNCH_VERIFY=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --launch-verify)
+            LAUNCH_VERIFY=true
+            ;;
+        --*)
+            echo "Error: unknown flag: $arg"
+            echo "Usage: $0 /path/to/built/\"Mio Island.app\" [--launch-verify]"
+            exit 1
+            ;;
+        *)
+            if [[ -z "$SOURCE" ]]; then
+                SOURCE="$arg"
+            else
+                echo "Error: unexpected argument: $arg"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
 # ── 1. Validate source ────────────────────────────────────────────────────────
 
-SOURCE="${1:-}"
 if [[ -z "$SOURCE" ]]; then
-    echo "Usage: $0 /path/to/built/\"Mio Island.app\""
+    echo "Usage: $0 /path/to/built/\"Mio Island.app\" [--launch-verify]"
     exit 1
 fi
 
@@ -112,14 +145,68 @@ if [[ -e "$NESTED_CHECK" ]]; then
 fi
 echo "No-nesting assertion: OK"
 
+# ── 8. Launch-verify (optional) ──────────────────────────────────────────────
+# Open the installed app and assert lsappinfo shows the correct bundle path.
+# This catches the case where the OS launches a stale DerivedData copy instead.
+
+if [[ "$LAUNCH_VERIFY" == "true" ]]; then
+    echo ""
+    echo "Launch-verify: opening $TARGET..."
+    open "$TARGET"
+
+    # Wait up to 10 seconds for the process to appear and register with lsappinfo.
+    VERIFY_TIMEOUT=10
+    VERIFY_ELAPSED=0
+    BUNDLE_PATH=""
+    while [[ $VERIFY_ELAPSED -lt $VERIFY_TIMEOUT ]]; do
+        sleep 1
+        VERIFY_ELAPSED=$((VERIFY_ELAPSED + 1))
+        # lsappinfo uses the display name; match case-insensitively to be safe.
+        BUNDLE_PATH=$(lsappinfo list 2>/dev/null \
+            | awk '/[Mm]io [Ii]sland/{found=1} found && /bundle path/{print; exit}' \
+            | sed 's/.*bundle path = *//' \
+            | tr -d '"')
+        if [[ -n "$BUNDLE_PATH" ]]; then
+            break
+        fi
+    done
+
+    if [[ -z "$BUNDLE_PATH" ]]; then
+        echo "ERROR: Launch-verify failed — '$APP_PROCESS_NAME' did not appear in lsappinfo after ${VERIFY_TIMEOUT}s."
+        echo "The app may have crashed on launch, or lsappinfo could not find it."
+        exit 1
+    fi
+
+    # Normalize trailing slash differences for comparison.
+    EXPECTED_BUNDLE_PATH="$TARGET"
+    ACTUAL_NORMALIZED="${BUNDLE_PATH%/}"
+    EXPECTED_NORMALIZED="${EXPECTED_BUNDLE_PATH%/}"
+
+    if [[ "$ACTUAL_NORMALIZED" != "$EXPECTED_NORMALIZED" ]]; then
+        echo "ERROR: Launch-verify FAILED — running instance is from the wrong path!"
+        echo "   Expected: $EXPECTED_BUNDLE_PATH"
+        echo "   Actual:   $BUNDLE_PATH"
+        echo "The OS may have launched a stale DerivedData or quarantined copy."
+        exit 1
+    fi
+
+    echo "Launch-verify: OK — running from $BUNDLE_PATH"
+fi
+
 echo ""
 echo "✅ Install complete."
 echo "   Path:    $TARGET"
 echo "   Version: $INSTALLED_VERSION ($INSTALLED_BUILD)"
 echo "   Bundle:  $INSTALLED_BUNDLE_ID"
+if [[ "$LAUNCH_VERIFY" == "true" ]]; then
+    echo "   Running: $BUNDLE_PATH (launch-verify passed)"
+fi
 echo ""
-echo "To launch and verify running path:"
-echo "   open \"$TARGET\""
-echo "   # After launch, run the following to confirm the process is from /Applications:"
-echo "   lsappinfo list | grep -A2 'Mio Island' | grep 'bundle path'"
-echo "   # Expected: bundle path = $TARGET"
+if [[ "$LAUNCH_VERIFY" != "true" ]]; then
+    echo "To launch and verify running path:"
+    echo "   open \"$TARGET\""
+    echo "   # After launch, run the following to confirm the process is from /Applications:"
+    echo "   lsappinfo list | grep -A2 'Mio Island' | grep 'bundle path'"
+    echo "   # Expected: bundle path = $TARGET"
+    echo "   # Or re-run with --launch-verify to automate this check."
+fi

--- a/scripts/safe-install-app.sh
+++ b/scripts/safe-install-app.sh
@@ -98,11 +98,28 @@ fi
 
 INSTALLED_VERSION=$(defaults read "$TARGET/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "unknown")
 INSTALLED_BUILD=$(defaults read "$TARGET/Contents/Info" CFBundleVersion 2>/dev/null || echo "unknown")
+
+# ── 7. No-nesting assertion ───────────────────────────────────────────────────
+# After cp -R into the PARENT dir, the bundle must NOT contain itself as a child.
+# If nesting occurred, source was accidentally copied INTO target instead of replacing it.
+
+NESTED_CHECK="$TARGET/$(basename "$SOURCE")"
+if [[ -e "$NESTED_CHECK" ]]; then
+    echo "ERROR: Nesting detected — $NESTED_CHECK exists inside the installed bundle!"
+    echo "This means the install procedure copied source INTO target instead of replacing it."
+    echo "Remove the nested bundle manually: rm -rf \"$NESTED_CHECK\""
+    exit 1
+fi
+echo "No-nesting assertion: OK"
+
 echo ""
 echo "✅ Install complete."
 echo "   Path:    $TARGET"
 echo "   Version: $INSTALLED_VERSION ($INSTALLED_BUILD)"
 echo "   Bundle:  $INSTALLED_BUNDLE_ID"
 echo ""
-echo "To launch:"
+echo "To launch and verify running path:"
 echo "   open \"$TARGET\""
+echo "   # After launch, run the following to confirm the process is from /Applications:"
+echo "   lsappinfo list | grep -A2 'Mio Island' | grep 'bundle path'"
+echo "   # Expected: bundle path = $TARGET"

--- a/scripts/safe-install-app.sh
+++ b/scripts/safe-install-app.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# safe-install-app.sh — Replace /Applications/Mio Island.app without nesting.
+#
+# Usage:
+#   ./scripts/safe-install-app.sh /path/to/built/"Mio Island.app"
+#
+# What this script does (in order):
+#   1. Validates the source .app exists and is a real Mio Island bundle.
+#   2. Quits any running "Mio Island" process gracefully (SIGTERM → wait → SIGKILL).
+#   3. Removes the old /Applications/Mio Island.app (avoids cp -R nesting bug).
+#   4. Copies the new bundle into /Applications/.
+#   5. Clears Gatekeeper quarantine so the app opens without prompts.
+#   6. Verifies the installed CFBundleIdentifier matches the expected value.
+#
+# Background (why this matters):
+#   `cp -R source.app /Applications/existing.app` nests source INSIDE destination
+#   instead of replacing it. You end up opening the old outer bundle.
+#   The fix is: rm -rf first, then cp -R into the PARENT directory.
+#
+# Incident reference: 2026-05-22 — the old /Applications/Mio Island.app contained
+#   the new build nested at /Applications/Mio Island.app/Mio Island.app, so Laurent
+#   was running the old version even after the "install". (@운위 caught and un-nested.)
+
+set -euo pipefail
+
+EXPECTED_BUNDLE_ID="com.codeisland.app"
+TARGET="/Applications/Mio Island.app"
+APP_PROCESS_NAME="Mio Island"
+
+# ── 1. Validate source ────────────────────────────────────────────────────────
+
+SOURCE="${1:-}"
+if [[ -z "$SOURCE" ]]; then
+    echo "Usage: $0 /path/to/built/\"Mio Island.app\""
+    exit 1
+fi
+
+if [[ ! -d "$SOURCE" ]]; then
+    echo "Error: source not found or not a directory: $SOURCE"
+    exit 1
+fi
+
+# Confirm it's the right bundle by checking CFBundleIdentifier.
+SOURCE_BUNDLE_ID=$(defaults read "$SOURCE/Contents/Info" CFBundleIdentifier 2>/dev/null || true)
+if [[ "$SOURCE_BUNDLE_ID" != "$EXPECTED_BUNDLE_ID" ]]; then
+    echo "Error: source bundle ID is '$SOURCE_BUNDLE_ID', expected '$EXPECTED_BUNDLE_ID'."
+    echo "Are you pointing at the right .app?"
+    exit 1
+fi
+
+echo "Source verified: $SOURCE ($SOURCE_BUNDLE_ID)"
+
+# ── 2. Quit running instance ──────────────────────────────────────────────────
+
+if pgrep -x "$APP_PROCESS_NAME" > /dev/null 2>&1; then
+    echo "Quitting running '$APP_PROCESS_NAME'..."
+    # Try graceful quit via AppleScript first.
+    osascript -e "quit app \"$APP_PROCESS_NAME\"" 2>/dev/null || true
+    # Give it 3 seconds to exit cleanly.
+    sleep 3
+    # If still running, force-kill.
+    if pgrep -x "$APP_PROCESS_NAME" > /dev/null 2>&1; then
+        echo "  Still running — sending SIGKILL..."
+        pkill -KILL -x "$APP_PROCESS_NAME" 2>/dev/null || true
+        sleep 1
+    fi
+    echo "  Done."
+else
+    echo "No running '$APP_PROCESS_NAME' found — skipping quit."
+fi
+
+# ── 3. Remove old bundle ──────────────────────────────────────────────────────
+# CRITICAL: rm -rf first. cp -R into an existing .app nests source inside target.
+
+if [[ -e "$TARGET" ]]; then
+    echo "Removing old bundle: $TARGET"
+    rm -rf "$TARGET"
+fi
+
+# ── 4. Copy new bundle ───────────────────────────────────────────────────────
+
+echo "Copying $SOURCE → /Applications/"
+cp -R "$SOURCE" "/Applications/"
+
+# ── 5. Clear Gatekeeper quarantine ───────────────────────────────────────────
+
+echo "Clearing quarantine attribute..."
+xattr -rd com.apple.quarantine "$TARGET" 2>/dev/null || true
+
+# ── 6. Verify installed bundle ───────────────────────────────────────────────
+
+INSTALLED_BUNDLE_ID=$(defaults read "$TARGET/Contents/Info" CFBundleIdentifier 2>/dev/null || true)
+if [[ "$INSTALLED_BUNDLE_ID" != "$EXPECTED_BUNDLE_ID" ]]; then
+    echo "ERROR: Installed bundle ID mismatch: got '$INSTALLED_BUNDLE_ID', expected '$EXPECTED_BUNDLE_ID'."
+    echo "Installation may be corrupt — check $TARGET manually."
+    exit 1
+fi
+
+INSTALLED_VERSION=$(defaults read "$TARGET/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "unknown")
+INSTALLED_BUILD=$(defaults read "$TARGET/Contents/Info" CFBundleVersion 2>/dev/null || echo "unknown")
+echo ""
+echo "✅ Install complete."
+echo "   Path:    $TARGET"
+echo "   Version: $INSTALLED_VERSION ($INSTALLED_BUILD)"
+echo "   Bundle:  $INSTALLED_BUNDLE_ID"
+echo ""
+echo "To launch:"
+echo "   open \"$TARGET\""


### PR DESCRIPTION
Account-only identity refactor for the Mac monitoring/enrollment side, plus enrollment robustness.

## What's here
- **Ownerless machine auth**: the Mac authenticates/pushes via its enrollment `machine_token` at the de-ownered `POST /v1/auth/machine`; ownership lives in the server-side `AccountComputerLink` (set by a phone scan), not on the device.
- **machine_token → device JWT + shortCode** monitoring bootstrap (reads the mio-agent Keychain item via `security`, no prompt) so one QR pairs workspace + monitoring.
- **Binary-fallback enrollment**: `MioAgentLauncher` resolves npx-cached or installed binary; retries on the installed binary when npx exits non-zero with no intent. Removed temporary dbg instrumentation.

## ⚠️ Heads-up for reviewers
- This branch is based on the **v2.3.0** line and is **diverged from `main` (v3.0.4)** — it does NOT contain the team's token-usage-meter / PR #88–#90 work. **Merging requires reconciling with v3.0.4 (expect conflicts).**
- Part of a 3-repo account-only refactor (MioServer + CodeLight + MioIsland). Server contract/spec: MioServer `docs/specs/2026-06-03-account-only-identity-design.md`.
- Known follow-ups (server-side, separate repo): phone session-message *send* route still device-JWT scoped; "create agent on phone → daemon auto-runs it" not yet wired; some legacy DeviceLink/`/v1/pairing/links` client calls 404 gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)