### PR TITLE
fix(cmux): 用真实 Enter 按键提交,不再只特判 Codex —— 修复 Claude 会话多行被拆条 / 长消息搁浅在输入框

### DIFF
--- a/ClaudeIsland/Services/Sync/TerminalWriter.swift
+++ b/ClaudeIsland/Services/Sync/TerminalWriter.swift
@@ -100,23 +100,33 @@ final class TerminalWriter {
         return detectedFallback
     }
 
-    /// Codex's TUI runs in raw mode with bracketed paste: a `\r` in the text
-    /// stream is a literal newline in its composer, never a submit. It only
-    /// submits on a real Enter *key* event. That's true whether or not we
-    /// resolved an explicit cmux surface — `cmux send-key` targets the
-    /// workspace's active surface when `--surface` is omitted — so Codex must
-    /// ALWAYS take the send-then-key path. Gating this on `hasSurfaceTarget`
-    /// was the bug: with no surface it fell back to the inline-`\r` path, which
-    /// strands the text in Codex's composer unsent. `hasSurfaceTarget` is kept
-    /// for callers/diagnostics but no longer changes Codex's submit path.
+    /// Every agent TUI we drive through cmux — Claude Code, Codex, Gemini,
+    /// opencode — runs in raw mode with bracketed paste, so an inline `\r` is
+    /// not a reliable way to submit:
+    ///
+    /// - Short payloads happen to submit, because cmux writes them as raw
+    ///   keystrokes and `\r` *is* the Enter key.
+    /// - Past a payload-size threshold (measured at ~128 bytes against
+    ///   cmux 0.64.17) cmux switches to a bulk-text path, where the trailing
+    ///   `\r` is inserted as a literal newline and the message is **stranded in
+    ///   the composer, unsent** — while the phone still reports "delivered".
+    /// - Worse, mapping every `\n` to `\r` means each newline is an Enter, so a
+    ///   single multi-line message is **split into several submitted messages**.
+    ///
+    /// A real Enter *key* event has none of these problems and is correct for
+    /// every payload size and shape, so it is now the only path. This function
+    /// only ever feeds the cmux backend, and `cmux send-key` targets the
+    /// workspace's active surface when `--surface` is omitted — the same
+    /// surface `cmux send` just wrote to — so it is safe with or without an
+    /// explicit surface. `terminalApp` / `hasSurfaceTarget` are kept for
+    /// callers and diagnostics but no longer change the submit path.
+    ///
+    /// Previously only `terminalApp == "codex"` took this path. That check
+    /// could never fire for a Claude Code session running inside cmux, whose
+    /// `terminalApp` is `cmux` — `terminalApp` names the *terminal*, not the
+    /// agent — so Claude kept the broken inline-`\r` path.
     nonisolated static func cmuxSubmissionPlan(text: String, terminalApp: String?, hasSurfaceTarget: Bool) -> CmuxSubmissionPlan {
-        let normalizedApp = terminalApp?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalizedApp == "codex" {
-            return .sendThenKey(text: text, key: "enter")
-        }
-
-        let escaped = text.replacingOccurrences(of: "\n", with: "\r")
-        return .appendReturn("\(escaped)\r")
+        .sendThenKey(text: text, key: "enter")
     }
 
     // MARK: - Diagnostics (for Settings → cmux Connection tab)

--- a/ClaudeIslandTests/TerminalWriterRoutingTests.swift
+++ b/ClaudeIslandTests/TerminalWriterRoutingTests.swift
@@ -48,14 +48,48 @@ final class TerminalWriterRoutingTests: XCTestCase {
         XCTAssertEqual(plan, .sendThenKey(text: "OK", key: "enter"))
     }
 
-    func test_standardCmuxSubmissionAppendsReturnInline() {
+    /// Regression (phone→terminal): a Claude Code session running inside cmux
+    /// reports `terminalApp == "cmux"`, so the old `== "codex"` check never
+    /// fired and it fell back to the inline-`\r` path. Every agent TUI cmux
+    /// drives needs a real Enter key event, so this is now the only path.
+    func test_nonCodexCmuxSubmissionAlsoUsesSeparateEnterKey() {
+        for app in ["cmux", "Ghostty", "iTerm2", nil] {
+            let plan = TerminalWriter.cmuxSubmissionPlan(
+                text: "OK",
+                terminalApp: app,
+                hasSurfaceTarget: true
+            )
+
+            XCTAssertEqual(plan, .sendThenKey(text: "OK", key: "enter"), "terminalApp: \(app ?? "nil")")
+        }
+    }
+
+    /// Regression: the old path mapped every `\n` to `\r`, and `\r` is the Enter
+    /// key — so one multi-line message was submitted as several separate
+    /// messages. Newlines must survive as newlines.
+    func test_multilineTextIsNotSplitIntoSeparateSubmissions() {
         let plan = TerminalWriter.cmuxSubmissionPlan(
-            text: "OK",
-            terminalApp: "Ghostty",
+            text: "line one\nline two\nline three",
+            terminalApp: "cmux",
             hasSurfaceTarget: true
         )
 
-        XCTAssertEqual(plan, .appendReturn("OK\r"))
+        XCTAssertEqual(plan, .sendThenKey(text: "line one\nline two\nline three", key: "enter"))
+    }
+
+    /// Regression: past a payload-size threshold (~128 bytes on cmux 0.64.17)
+    /// cmux writes text through a bulk path where a trailing `\r` is a literal
+    /// newline, stranding the message in the composer unsent. A key event is
+    /// size-independent.
+    func test_longTextStillUsesSeparateEnterKey() {
+        let long = String(repeating: "z", count: 4096)
+        let plan = TerminalWriter.cmuxSubmissionPlan(
+            text: long,
+            terminalApp: "cmux",
+            hasSurfaceTarget: true
+        )
+
+        XCTAssertEqual(plan, .sendThenKey(text: long, key: "enter"))
     }
 
     /// Regression: Codex's raw-mode TUI only submits on a real Enter KEY event;


### PR DESCRIPTION
Fixes #96.

## 问题

从 iPhone 往一个**跑在 cmux 里的 Claude Code 会话**发消息时:

| 消息形态 | 结果 |
|---|---|
| 短的单行 | ✅ 正常 |
| **短的多行** | ⚠️ **被拆成多条消息分别提交**(每行一条) |
| **总长超过 ~128 字节** | ❌ **整条搁浅在 composer 里不提交**,而手机端仍显示"已送达" |

失败是完全静默的,实际使用中意味着手机端基本只能发短句。

## 根因

`cmuxSubmissionPlan()` 只在 `terminalApp == "codex"` 时才走 `sendThenKey`:

```swift
if normalizedApp == "codex" {
    return .sendThenKey(text: text, key: "enter")
}
let escaped = text.replacingOccurrences(of: "\n", with: "\r")
return .appendReturn("\(escaped)\r")
```

**这个判断对 cmux 里的 Claude 会话永远不可能命中** —— `terminalApp` 指的是**终端**而不是 **agent**(现有测试传的就是 `"Ghostty"`;hook 日志里是 `termApp=cmux`)。于是 Claude 落到了 `appendReturn`,而这条路有两个问题:

1. **`\r` 就是 Enter 键。** 把文本里每个 `\n` 都换成 `\r`,等于在每个换行处按一次回车 → **一条多行消息被拆成 N 条分别提交**。
2. **超过一定长度后,`\r` 失去 Enter 语义。** cmux 对大 payload 会切到 bulk-text 通道(见 manaflow-ai/cmux#2396 / #2397),此时末尾的 `\r` 只是一个字面换行 → **文字进了 composer 但不提交**。

这正是本文件注释里早已为 Codex 描述过的失效模式(*"strands the text in Codex's composer unsent"*)—— **Claude Code 的 TUI 具有完全相同的性质**,只是没被纳入。

## 实测(cmux 0.64.17 + Claude Code 2.1.207)

在一个跑着 `claude` 的 cmux surface 上,直接用 CLI 复现 `appendReturn` 的行为(文字末尾拼 `\r`、不发按键):

| 消息总长 | 结果 |
|---|---|
| ~106 字节 | ✅ 提交 |
| **~196 字节** | ❌ **搁浅在 composer** |
| ~256 / ~266 / ~700 字节 | ❌ 搁浅 |

阈值落在 106–196 字节之间(未进一步二分,推测是 128 字节的缓冲区边界)。

而改用 `send` + `send-key enter` 两步,**任意长度、任意换行都能正确提交**。

## 改动

让 `sendThenKey` 成为 cmux 提交路径的**唯一**选择:

```swift
nonisolated static func cmuxSubmissionPlan(text: String, terminalApp: String?, hasSurfaceTarget: Bool) -> CmuxSubmissionPlan {
    .sendThenKey(text: text, key: "enter")
}
```

理由:

- 凡是经 cmux 驱动的 agent TUI(Claude / Codex / Gemini / opencode …)**都是 raw-mode + bracketed paste**,inline `\r` 对它们全都不可靠且**长度相关**。逐个特判 agent 迟早会漏 —— 这次就漏了 Claude。
- 这个函数**本来就只服务于 cmux 这一条注入路径**,而真实的 Enter 按键事件对所有 payload 大小和形态都正确。
- 对纯 shell surface 同样安全:`cmux send "ls"` + `cmux send-key enter` 与 inline `\r` 等效。
- `\n` → `\r` 的替换一并去掉(原样发送文本),多行拆条问题随之消失。

`terminalApp` / `hasSurfaceTarget` 两个参数保留(调用方和诊断页仍在用),只是不再影响提交路径。

## 风险

**很低。** `sendThenKey` 这条分支(含 150ms 的 composer settle 延迟)自 4 月起就在生产中为 Codex 服务,本 PR 只是让其余 agent 也走它。`.appendReturn` 这个 case 及其 switch 分支予以保留(现已不可达),以便最小化 diff —— 如果你希望一并删掉,我可以加一个 commit。

## 测试

- 替换了 `test_standardCmuxSubmissionAppendsReturnInline` —— 它**把这个 bug 的行为固化成了断言**。
- 新增三个回归测试:
  - `test_nonCodexCmuxSubmissionAlsoUsesSeparateEnterKey`(覆盖 `cmux` / `Ghostty` / `iTerm2` / `nil`)
  - `test_multilineTextIsNotSplitIntoSeparateSubmissions`
  - `test_longTextStillUsesSeparateEnterKey`(4096 字节)
- Codex 原有的三个测试**保持不变、依然通过**。
